### PR TITLE
Fix sidebar scroll behavior with fixed preview

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -239,7 +239,7 @@ button:hover {
   display: grid;
   grid-template-columns: minmax(480px, 480px) 1fr;
   gap: 0;
-  min-height: 100vh;
+  height: 100vh;
   background: #0b0d12; /* dark canvas */
   transition: all 0.3s ease;
   position: relative;
@@ -251,10 +251,10 @@ button:hover {
   grid-template-columns: 32px 1fr;
 }
 
-.sidebar { 
-  position: relative; 
-  background: #0f131a; 
-  color: #dfe6f3; 
+.sidebar {
+  position: relative;
+  background: #0f131a;
+  color: #dfe6f3;
   border-right: 1px solid #1c2330;
   transition: all 0.3s ease;
   height: 100vh;
@@ -262,9 +262,17 @@ button:hover {
   flex-shrink: 0;
 }
 
+.sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
 .form-scroll {
   overflow-x: hidden;
   overflow-y: auto;
+  flex: 1;
 }
 
 .sidebar > * {
@@ -288,17 +296,16 @@ button:hover {
   pointer-events: none;
 }
 
-.collapse { 
+.collapse {
   position: absolute;
-  top: 50%;
+  top: 12px;
   right: -32px;
-  width: 40px; 
-  height: 48px; 
-  border-radius: 12px; 
-  background: #0f131a; 
+  width: 40px;
+  height: 48px;
+  border-radius: 12px;
+  background: #0f131a;
   color: #475468;
   box-shadow: none;
-  transform: translateY(-50%);
   cursor: pointer;
   display: flex !important;
   align-items: center;
@@ -340,7 +347,7 @@ button:hover {
 }
 
 .collapse:hover {
-  transform: translateY(-50%) !important;
+  transform: none !important;
 }
 
 .collapse:hover svg {
@@ -361,12 +368,12 @@ button:hover {
   box-shadow: 0 0 12px rgba(255, 59, 59, 0.15);
 }
 
-.form-scroll { 
-  padding: 24px 52px 80px 20px; 
-  height: 100vh; 
+.form-scroll {
+  padding: 24px 52px 80px 20px;
   overflow-y: auto;
   overflow-x: hidden;
   margin: 0 auto;
+  flex: 1;
 }
 
 .topbar { 
@@ -732,7 +739,7 @@ textarea {
 @keyframes spin { to { transform: rotate(360deg); } }
 
 /* Preview */
-.preview { 
+.preview {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -741,7 +748,7 @@ textarea {
   overflow-y: auto;
   overflow-x: hidden;
   gap: 40px; /* Space between pages */
-  min-height: 100%;
+  height: 100vh;
   box-sizing: border-box;
 }
 

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -1,6 +1,6 @@
 /* Preview Styles */
 
-.preview { 
+.preview {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -9,7 +9,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   gap: 40px; /* Space between pages */
-  min-height: 100%;
+  height: 100vh;
   box-sizing: border-box;
   counter-reset: page; /* Initialize page counter */
 }


### PR DESCRIPTION
## Summary
- Keep main layout fixed to viewport height and convert sidebar to a flex column for independent scrolling
- Move collapse button to top and size preview pane to its own scrollable viewport

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c618c840c83328bdcf89678e8168b