### PR TITLE
feat: paginate resume preview with page numbers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -391,73 +391,76 @@ button:hover {
 .topbar h2 { font-size: 16px; font-weight: 600; letter-spacing: .2px; color: #e5edff; margin: 0 8px; }
 .topbar .right { display: flex; gap: 8px; }
 
-.btn { 
-  appearance: none; 
-  border: 1px solid #2a3446; 
-  background: #141a22; 
-  color: #e9f0ff; 
-  padding: 8px 16px; 
-  border-radius: 10px; 
-  font-size: 13px; 
+.btn {
+  appearance: none;
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  color: var(--text-color);
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 8px;
   height: 36px;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.btn:hover { 
-  border-color: #415275;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,.2);
+.btn:hover {
+  border-color: var(--accent-color);
+  transform: scale(1.02);
+  box-shadow: var(--subtle-shadow);
 }
 
-.btn.primary { 
-  background: #3358ff; 
-  border-color: #3358ff;
+.btn.primary {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
   padding: 8px 20px;
-  font-weight: 500;
-  box-shadow: 0 4px 12px rgba(51,88,255,.25);
+  font-weight: 600;
+  box-shadow: var(--subtle-shadow);
 }
 
-.btn.primary:hover { 
-  filter: brightness(1.05);
-  transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(51,88,255,.3);
+.btn.primary:hover {
+  background: var(--accent-color-hover);
+  transform: scale(1.02);
+  box-shadow: var(--elevated-shadow);
 }
 
-.btn.ghost { 
-  background: #10151c;
-  border-color: #2a3446;
+.btn.ghost {
+  background: var(--surface-color);
+  border-color: var(--border-color);
 }
 
-.card { 
-  background: #0b1017; 
-  border: 1px solid #1d2737; 
-  border-radius: 14px; 
-  padding: 20px; 
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 20px;
   margin: 24px 0;
   width: 100%;
   max-width: 480px;
   position: relative;
-  transition: all 0.2s ease;
+  box-shadow: var(--subtle-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  animation: fadeSlideIn 0.4s ease;
 }
 .card:hover {
-  border-color: #2a3651;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,.15);
+  border-color: var(--accent-color);
+  transform: translateY(-2px);
+  box-shadow: var(--elevated-shadow);
 }
-.card h3 { 
-  margin: 0 0 20px; 
-  font-size: 18px; 
-  color: #ffffff;
+.card h3 {
+  margin: 0 0 20px;
+  font-size: 18px;
+  color: var(--text-color);
   display: flex;
   align-items: center;
   justify-content: space-between;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
+  font-family: var(--font-heading);
 }
 .card h3 button {
   margin-left: 8px;
@@ -507,12 +510,12 @@ button:hover {
 }
 
 /* Inputs */
-label { 
-  display: grid; 
-  gap: 6px; 
-  margin-bottom: 14px; 
-  font-size: 12px; 
-  color: #9fb3d9;
+label {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+  font-size: 12px;
+  color: var(--muted-text);
   font-weight: 500;
 }
 
@@ -806,22 +809,6 @@ textarea {
   border-bottom-right-radius: 50%;
 }
 
-/* Page number indicator */
-.preview-paper::after {
-  content: 'Page ' counter(page);
-  position: absolute;
-  bottom: 10mm;
-  right: 10mm;
-  font-size: 10px;
-  color: #666;
-  counter-increment: page;
-}
-
-/* Initialize page counter */
-.preview {
-  counter-reset: page;
-}
-
 /* Page break indicator */
 .preview-paper[style*="height: 297mm"]:not(:last-child)::before {
   content: '';
@@ -906,15 +893,16 @@ textarea {
   padding: 8px 12px;
   margin-top: 20px;
   border: none;
-  border-radius: 4px;
-  background: #3358ff;
+  border-radius: 8px;
+  background: var(--accent-color);
   color: #fff;
   font-size: 14px;
   font-weight: 600;
   text-decoration: none;
-  transition: background 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .btn:hover{
-  background: #254edb;
+  background: var(--accent-color-hover);
+  transform: scale(1.02);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { useReactToPrint } from 'react-to-print';
 import './App.css';
 
 // Forms
 import ExperienceForm from './sections/experiences';
 import EducationForm from './sections/education';
-import Resume from './sections/resume';
+import ResumePreview from './components/ResumePreview';
 import SkillForm from './sections/skills';
 import ProjectForm from './sections/projects';
 
@@ -175,7 +175,7 @@ function App() {
           <ResumeImprover resumeData={data} setData={setData} />
         </>
       }
-      preview={<div className="preview-container" ref={printRef}><div className="preview-paper"><Resume data={data} /></div></div>}
+      preview={<ResumePreview ref={printRef} data={data} />}
     />
   );
 }

--- a/src/components/ResumePreview.jsx
+++ b/src/components/ResumePreview.jsx
@@ -1,0 +1,119 @@
+/* eslint-disable react/prop-types */
+import { forwardRef, useEffect, useRef, useState } from 'react';
+import Resume from '../sections/resume';
+
+// Convert millimeters to pixels (96 DPI)
+const mmToPx = (mm) => (mm * 96) / 25.4;
+
+// Available content height inside the page (excluding padding and footer space)
+const PAGE_CONTENT_HEIGHT = mmToPx(297 - 25 - 35); // 237mm
+
+// Helper to measure a node's outer height including margins
+const getOuterHeight = (node) => {
+  const style = window.getComputedStyle(node);
+  return (
+    node.offsetHeight +
+    parseFloat(style.marginTop || 0) +
+    parseFloat(style.marginBottom || 0)
+  );
+};
+
+const ResumePreview = forwardRef(function ResumePreview({ data }, ref) {
+  const measureRef = useRef(null);
+  const [pages, setPages] = useState([]);
+
+  useEffect(() => {
+    const container = measureRef.current;
+    if (!container) return;
+
+    const newPages = [];
+    let currentPage = [];
+    let currentHeight = 0;
+
+    const pushPage = () => {
+      if (currentPage.length) {
+        newPages.push(currentPage);
+        currentPage = [];
+        currentHeight = 0;
+      }
+    };
+
+    const addNode = (node) => {
+      currentPage.push(node.cloneNode(true));
+      currentHeight += getOuterHeight(node);
+    };
+
+    // Top block (name + contact)
+    const top = container.querySelector('.top');
+    if (top) {
+      if (getOuterHeight(top) > PAGE_CONTENT_HEIGHT && currentPage.length) {
+        pushPage();
+      }
+      addNode(top);
+    }
+
+    // Process each resume section
+    container.querySelectorAll('.section').forEach((section) => {
+      const header = section.querySelector('.section-title');
+      const entries = Array.from(section.children).filter(
+        (child) => child !== header
+      );
+
+      entries.forEach((entry, index) => {
+        const entryHeight = getOuterHeight(entry);
+
+        if (index === 0) {
+          const headerHeight = getOuterHeight(header);
+          if (
+            currentHeight + headerHeight + entryHeight > PAGE_CONTENT_HEIGHT &&
+            currentPage.length
+          ) {
+            pushPage();
+          }
+
+          addNode(header);
+        } else if (
+          currentHeight + entryHeight > PAGE_CONTENT_HEIGHT &&
+          currentPage.length
+        ) {
+          pushPage();
+        }
+
+        addNode(entry);
+      });
+    });
+
+    pushPage();
+
+    // Convert page nodes to HTML strings
+    const htmlPages = newPages.map((nodes) =>
+      nodes.map((n) => n.outerHTML).join('')
+    );
+
+    setPages(htmlPages);
+  }, [data]);
+
+  return (
+    <>
+      {/* Hidden container for measuring content */}
+      <div ref={measureRef} className="preview-measure">
+        <Resume data={data} />
+      </div>
+
+      <div className="preview-container" ref={ref}>
+        {pages.map((html, i) => (
+          <div
+            key={i}
+            className="preview-paper"
+            data-total={pages.length}
+          >
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+export default ResumePreview;
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,21 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Lora:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Source+Sans+Pro:wght@400;600&display=swap');
 
 :root {
   /* Color Palette */
-  --base-color: #1A202C; /* Deep Navy */
-  --accent-color: #008080; /* Teal */
-  --text-color: #E2E8F0;
-  --card-bg: #2D3748;
-  --border-color: #4A5568;
-  --subtle-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --base-color: #0f172a; /* Deep Navy */
+  --surface-color: #1e293b; /* Card surface */
+  --accent-color: #0ea5e9; /* Teal accent */
+  --accent-color-hover: #38bdf8;
+  --text-color: #f1f5f9;
+  --muted-text: #94a3b8;
+  --card-bg: var(--surface-color);
+  --border-color: #334155;
+  --subtle-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  --elevated-shadow: 0 8px 16px rgba(0,0,0,0.15);
 
   /* Typography */
-  --font-heading: 'Poppins', sans-serif;
-  --font-body: 'Lora', serif;
+  --font-heading: 'Montserrat', sans-serif;
+  --font-body: 'Source Sans Pro', sans-serif;
 
   font-family: var(--font-body);
   line-height: 1.5;
@@ -29,11 +33,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--accent-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--accent-color-hover);
 }
 
 body {
@@ -49,23 +53,41 @@ h1 {
   line-height: 1.1;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+}
+
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: none;
   padding: 0.6em 1.2em;
   font-size: 1em;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--accent-color);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: var(--accent-color-hover);
+  transform: scale(1.02);
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(14,165,233,0.4);
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (prefers-color-scheme: light) {
@@ -74,9 +96,9 @@ button:focus-visible {
     background-color: #ffffff;
   }
   a:hover {
-    color: #747bff;
+    color: var(--accent-color-hover);
   }
   button {
-    background-color: #f9f9f9;
+    background-color: var(--accent-color);
   }
 }

--- a/src/sections/resume.css
+++ b/src/sections/resume.css
@@ -38,6 +38,8 @@ body {
 
 .education-item, .experience-item, .project-item {
     margin-bottom: 0.5em;
+    break-inside: avoid;
+    page-break-inside: avoid;
 }
 
 .education-header, .experience-header, .project-header, .education-details, .experience-details, .project-details {
@@ -56,6 +58,8 @@ body {
 
 .skills-list {
     columns: 2;
+    break-inside: avoid;
+    page-break-inside: avoid;
 }
 
 .skill-item {

--- a/src/styles/ai-suggestions.css
+++ b/src/styles/ai-suggestions.css
@@ -1,13 +1,21 @@
 /* AI Suggestions Styling */
 
 .ai-suggestion {
-  background: #0b1017; 
-  border: 1px solid #1d2737; 
-  border-radius: 14px; 
-  padding: 20px; 
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 20px;
   margin: 24px 0;
   width: 100%;
   max-width: 480px;
+  box-shadow: var(--subtle-shadow);
+  animation: fadeSlideIn 0.4s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ai-suggestion:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--elevated-shadow);
 }
 
 .card-header {
@@ -20,7 +28,7 @@
 .card-title {
   margin: 0;
   font-size: 18px;
-  color: #ffffff;
+  color: var(--text-color);
   font-weight: 600;
 }
 
@@ -49,15 +57,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: #9fb3d9;
+  color: var(--muted-text);
   font-size: 14px;
 }
 
 .spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid #3e4f70;
-  border-top-color: #3358ff;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--accent-color);
   border-radius: 50%;
   animation: spin .8s linear infinite;
 }
@@ -78,7 +86,7 @@
 }
 
 .hint {
-  color: #88a0c9;
+  color: var(--muted-text);
   font-size: 14px;
   margin: 8px 0;
 }
@@ -88,11 +96,11 @@
 }
 
 .suggestion-pre {
-  background: #0e1520;
-  border: 1px solid #243146;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 16px;
-  color: #e9f0ff;
+  color: var(--text-color);
   font-family: inherit;
   font-size: 14px;
   line-height: 1.5;
@@ -105,8 +113,8 @@
 
 .suggestion-card {
   position: relative;
-  background: #0e1520;
-  border: 1px solid #243146;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 12px 16px;
   margin-bottom: 12px;
@@ -114,7 +122,7 @@
 }
 
 .suggestion-card:hover {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
 }
 
 .skill-suggestions {
@@ -129,15 +137,15 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: #0e1520;
-  border: 1px solid #243146;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
   padding: 4px 8px;
   transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
 .skill-chip:hover {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
 }
 
 .remove-btn {
@@ -146,20 +154,20 @@
   right: 6px;
   background: transparent;
   border: none;
-  color: #9fb3d9;
+  color: var(--muted-text);
   cursor: pointer;
   font-size: 14px;
   line-height: 1;
 }
 
 .remove-btn:hover {
-  color: #ffffff;
+  color: var(--text-color);
 }
 
 .skill-chip .remove-btn {
   top: -6px;
   right: -6px;
-  background: #243146;
+  background: var(--border-color);
   border-radius: 50%;
   width: 16px;
   height: 16px;

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -19,7 +19,7 @@
 
 .description-item:before {
   content: "•";
-  color: #3358ff;
+  color: var(--accent-color);
   font-size: 1.2em;
   position: absolute;
   left: 8px;
@@ -44,16 +44,16 @@
   font-size: 13px;
   white-space: pre-wrap;
   margin-right: 8px;
-  background-color: #0e1520;
-  border: 1px solid #243146;
-  border-radius: 10px;
-  color: #e9f0ff;
+  background-color: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-color);
 }
 
 .description-item textarea:focus {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px rgba(14,165,233,0.3);
 }
 
 .description-item .bullet-delete {
@@ -88,9 +88,9 @@
 /* Add Bullet Button */
 .add-bullet-btn {
   margin-top: 12px;
-  background: rgba(51, 88, 255, 0.1);
-  color: #3358ff;
-  border: 1px solid rgba(51, 88, 255, 0.2);
+  background: rgba(14,165,233,0.1);
+  color: var(--accent-color);
+  border: 1px solid rgba(14,165,233,0.2);
   padding: 8px 16px;
   border-radius: 8px;
   font-size: 13px;
@@ -99,7 +99,7 @@
 }
 
 .add-bullet-btn:hover {
-  background: rgba(51, 88, 255, 0.15);
+  background: rgba(14,165,233,0.15);
   transform: translateY(-1px);
 }
 
@@ -136,50 +136,50 @@
 }
 
 /* Form Inputs */
-input, textarea, select { 
+input, textarea, select {
   width: calc(100% - 28px);
   max-width: 400px;
   min-width: 200px;
-  padding: 12px 14px; 
-  border-radius: 10px; 
-  border: 1px solid #243146; 
-  background: #0e1520; 
-  color: #e9f0ff; 
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  color: var(--text-color);
   font-size: 13px;
   transition: all 0.2s ease;
   box-sizing: border-box;
 }
 
 input:focus, textarea:focus, select:focus {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px rgba(14,165,233,0.3);
 }
 
-label { 
-  display: grid; 
-  gap: 6px; 
-  margin-bottom: 12px; 
-  font-size: 12px; 
-  color: #9fb3d9;
+label {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: var(--muted-text);
   font-weight: 500;
 }
 
 /* Add Project/Experience Button */
 .add-new-btn {
   margin-top: 16px;
-  background: #3358ff;
-  color: white;
+  background: var(--accent-color);
+  color: #fff;
   border: none;
   padding: 10px 16px;
   border-radius: 8px;
   font-size: 14px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .add-new-btn:hover {
-  background: #4066ff;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(51,88,255,.25);
+  background: var(--accent-color-hover);
+  transform: scale(1.02);
+  box-shadow: var(--subtle-shadow);
 }

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -3,42 +3,69 @@
 .preview-container {
     overflow-y: auto;
     height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+    counter-reset: page; /* Initialize page counter */
 }
 
+.preview-measure {
+  position: absolute;
+  visibility: hidden;
+  top: 0;
+  left: -9999px;
+  width: 210mm;
+  padding: 25mm 25mm 35mm;
+  box-sizing: border-box;
+}
+
+/* legacy container retained for layout wrappers */
 .preview {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 40px;
-  background: #f0f2f5;
+  background: var(--base-color);
   overflow-x: hidden;
   gap: 40px; /* Space between pages */
   box-sizing: border-box;
-  counter-reset: page; /* Initialize page counter */
 }
 
 a {
     color: black;
 }
 
-.preview-paper { 
-  width: 210mm; 
-  height: 297mm; 
-  padding: 25mm 25mm;
-  background: #fff; 
-  color: #111; 
-  border-radius: 12px; 
-  box-shadow: 0 4px 24px rgba(0,0,0,.12),
-              0 12px 48px rgba(0,0,0,.12); 
+.preview-paper {
+  width: 210mm;
+  height: 297mm;
+  padding: 25mm 25mm 35mm;
+  background: #fff;
+  color: #111;
+  border-radius: 12px;
+  box-shadow: var(--subtle-shadow);
   position: relative;
   overflow: visible;
   page-break-after: always;
+  break-after: page;
   box-sizing: border-box;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.preview-paper:last-child {
+  page-break-after: avoid;
+  break-after: avoid;
+}
+
+.preview-paper:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--elevated-shadow);
 }
 
 /* Page number indicator */
 .preview-paper::after {
-  content: "Page " attr(data-page) " / " attr(data-total);
+  counter-increment: page;
+  content: 'Page ' counter(page) ' of ' attr(data-total);
   position: absolute;
   bottom: 10mm;
   right: 10mm;
@@ -51,10 +78,11 @@ a {
   color: #333;
   font-size: 20px;
   margin: 24px 0 16px;
-  border-bottom: 2px solid #3358ff;
+  border-bottom: 2px solid var(--accent-color);
   padding-bottom: 8px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  font-family: var(--font-heading);
 }
 
 .preview-paper h4 {
@@ -62,21 +90,13 @@ a {
   font-size: 16px;
   margin: 16px 0 8px;
   font-weight: 600;
+  font-family: var(--font-heading);
 }
 
 /* Additional page styling */
-.preview-paper:not(:first-child) {
-  margin-top: -20px; /* Overlap to show connection between pages */
-}
+/* Gap on container handles spacing between pages */
 
-.preview-paper:not(:last-child)::after {
-  content: "Page " attr(data-page) " / " attr(data-total);
-  position: absolute;
-  bottom: 10mm;
-  right: 10mm;
-  font-size: 10px;
-  color: #666;
-}
+
 
 /* Print */
 @media print {
@@ -94,24 +114,42 @@ a {
     display: none !important; 
   }
   
-  .layout { 
+  .layout {
     display: block !important;
     height: auto !important;
   }
-  
-  .preview { 
+
+  .preview-container {
+    overflow: visible !important;
+    height: auto !important;
+    display: block !important;
+    gap: 0 !important;
+  }
+
+  .preview {
     padding: 0 !important;
     height: auto !important;
     background: none !important;
   }
-  
-  .preview-paper { 
+
+  .preview-paper {
     width: 210mm !important;
     height: 297mm !important;
-    padding: 25mm !important;
+    padding: 25mm 25mm 35mm !important;
     margin: 0 !important;
     box-shadow: none !important;
     border-radius: 0 !important;
     position: relative !important;
+    page-break-after: always !important;
+    break-after: page !important;
+  }
+
+  .preview-paper:last-child {
+    page-break-after: avoid !important;
+    break-after: avoid !important;
+  }
+
+  .preview-measure {
+    display: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- split resume preview into measured A4 pages and show persistent page numbers
- style preview and print layouts to reserve footer space for numbering
- hook dynamic pagination into app preview for consistent on-screen and printed output
- keep Level-2 entry blocks intact across pages and move section headers only when their first entry overflows
- guard entry blocks from page-breaks in print
- ensure print view renders all pages by clearing preview container overflow
- ensure each preview page displays its footer and hide footers when printing
- render a single "Page X of Y" footer via CSS and suppress extra blank page at the end
- prevent hidden measuring markup from printing so first page no longer blanks and numbering stays accurate
- show page numbers in preview starting at page 1 and suppress them in print
- add design system refresh with modern palette, typography, and interactive UI elements
- show page-number footer on printed pages as well so page 1 displays its label

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react/prop-types and no-undef errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbf2ec2a48332a76a9db3b0b59bbf