### PR TITLE
Split AI suggestions into sectioned Groq requests

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,21 +14,32 @@
 .Forms {
   width: 480px; /* Consistent with layout shell width */
   padding: 10mm;
-  background-color: #f9f9f9; /* Light background color */
+  background: var(--surface-color);
+  color: var(--text-color);
+  border-radius: 8px;
+  box-shadow: var(--subtle-shadow);
 }
 
 label {
-  font-weight: bold;
-  color: #333; /* Darker text for better visibility */
+  font-weight: 600;
+  color: var(--muted-text);
+  font-size: 12px;
 }
 
 input {
   padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  background-color: #fff; /* White background for inputs */
-  color: #333; /* Darker text color for better contrast */
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--surface-color);
+  color: var(--text-color);
   width: 100%;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+  border-color: var(--accent-color);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 /* Experience section */
@@ -45,7 +56,7 @@ input {
 .experience-section .desc-container .desc-item:before,
 .project-section .desc-container .desc-item:before {
   content: "•";
-  color: #3358ff;
+  color: var(--accent-color);
   font-size: 1.2em;
   position: absolute;
   left: 8px;
@@ -71,17 +82,17 @@ input {
   font-size: 13px;
   white-space: pre-wrap;
   margin-right: 8px;
-  background-color: #0e1520;
-  border: 1px solid #243146;
-  border-radius: 10px;
-  color: var(--primary-text);
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-color);
 }
 
 .experience-section .desc-container .desc-item textarea:focus,
 .project-section .desc-container .desc-item textarea:focus {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .experience-section .desc-container .desc-item .bullet-delete,
@@ -119,7 +130,7 @@ input {
 .experience-section .desc-container textarea:focus {
   border-color: #3358ff;
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .experience-section .desc-container .bullet-delete {
@@ -251,114 +262,6 @@ button:hover {
   grid-template-columns: 32px 1fr;
 }
 
-.sidebar {
-  position: relative;
-  background: #0f131a;
-  color: #dfe6f3;
-  border-right: 1px solid #1c2330;
-  transition: all 0.3s ease;
-  height: 100vh;
-  width: 100%;
-  flex-shrink: 0;
-}
-
-.sidebar-inner {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  overflow: hidden;
-}
-
-.form-scroll {
-  overflow-x: hidden;
-  overflow-y: auto;
-  flex: 1;
-}
-
-.sidebar > * {
-  transition: opacity 0.3s ease, visibility 0.3s ease;
-}
-
-.layout.closed .sidebar {
-  width: 32px;
-  overflow: visible;
-}
-
-.layout.closed .form-scroll,
-.layout.closed .topbar {
-  opacity: 0;
-  visibility: hidden;
-}
-
-.layout.closed .sidebar > *:not(.collapse) {
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-}
-
-.collapse {
-  position: absolute;
-  top: 12px;
-  right: -32px;
-  width: 40px;
-  height: 48px;
-  border-radius: 12px;
-  background: #0f131a;
-  color: #475468;
-  box-shadow: none;
-  cursor: pointer;
-  display: flex !important;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  transition: all 0.2s ease;
-  opacity: 1 !important;
-  visibility: visible !important;
-  border: none;
-  outline: none;
-}
-
-/* Make the arrow icon more subtle */
-.collapse svg {
-  width: 18px;
-  height: 18px;
-  stroke-width: 1.25;
-  opacity: 0.6;
-  transition: opacity 0.2s ease;
-}
-
-/* Add a subtle connection effect to make it look attached */
-.collapse::before {
-  content: '';
-  position: absolute;
-  right: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 8px;
-  height: 24px;
-  background: linear-gradient(to right, transparent, #111827);
-  pointer-events: none;
-}
-
-/* Subtle state changes for collapse button */
-.layout.closed .collapse {
-  right: -36px;
-  background: #0f131a;
-}
-
-.collapse:hover {
-  transform: none !important;
-}
-
-.collapse:hover svg {
-  opacity: 0.8;
-}
-
-/* Remove focus outline */
-.collapse:focus {
-  outline: none;
-  box-shadow: none;
-}
 
 .delete-btn:hover {
   background: rgba(255, 59, 59, 0.2) !important;
@@ -368,96 +271,124 @@ button:hover {
   box-shadow: 0 0 12px rgba(255, 59, 59, 0.15);
 }
 
-.form-scroll {
-  padding: 24px 52px 80px 20px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  margin: 0 auto;
-  flex: 1;
-}
-
-.topbar { 
-  position: sticky; 
+.topbar {
+  position: sticky;
   top: 0;
-  z-index: 5; 
-  display: flex; 
-  align-items: center; 
-  justify-content: space-between; 
-  gap: 12px; 
-  padding: 10px 32px; 
-  margin: -2px 0px 4px -10px; 
-  border-bottom: 1px solid #1c2330; 
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 32px;
+  margin: -2px 0px 4px -10px;
+  background: var(--surface-color);
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: var(--subtle-shadow);
 }
-.topbar h2 { font-size: 16px; font-weight: 600; letter-spacing: .2px; color: #e5edff; margin: 0 8px; }
+.topbar h2 { font-size: 16px; font-weight: 600; letter-spacing: .2px; color: var(--text-color); margin: 0 8px; font-family: var(--font-heading); }
 .topbar .right { display: flex; gap: 8px; }
 
-.btn { 
-  appearance: none; 
-  border: 1px solid #2a3446; 
-  background: #141a22; 
-  color: #e9f0ff; 
-  padding: 8px 16px; 
-  border-radius: 10px; 
-  font-size: 13px; 
+.btn {
+  appearance: none;
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  color: var(--text-color);
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 8px;
   height: 36px;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.btn:hover { 
-  border-color: #415275;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,.2);
+.btn:hover {
+  border-color: var(--accent-color);
+  transform: scale(1.02);
+  box-shadow: var(--subtle-shadow);
 }
 
-.btn.primary { 
-  background: #3358ff; 
-  border-color: #3358ff;
+.btn.primary {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
   padding: 8px 20px;
-  font-weight: 500;
-  box-shadow: 0 4px 12px rgba(51,88,255,.25);
+  font-weight: 600;
+  box-shadow: var(--subtle-shadow);
 }
 
-.btn.primary:hover { 
-  filter: brightness(1.05);
-  transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(51,88,255,.3);
+.btn.primary:hover {
+  background: var(--accent-color-hover);
+  transform: scale(1.02);
+  box-shadow: var(--elevated-shadow);
 }
 
-.btn.ghost { 
-  background: #10151c;
-  border-color: #2a3446;
+.btn.ghost {
+  background: var(--surface-color);
+  border-color: var(--border-color);
 }
 
-.card { 
-  background: #0b1017; 
-  border: 1px solid #1d2737; 
-  border-radius: 14px; 
-  padding: 20px; 
+.btn.ghost.active {
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 20px;
   margin: 24px 0;
   width: 100%;
   max-width: 480px;
   position: relative;
-  transition: all 0.2s ease;
+  box-shadow: var(--subtle-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  animation: fadeSlideIn 0.4s ease;
+}
+
+.card.collapsible .collapse-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+.card.collapsible .collapse-toggle h3 {
+  margin: 0;
+}
+
+.card.collapsible.closed {
+  padding-bottom: 0;
+}
+
+.card.collapsible .card-body {
+  margin-top: 20px;
 }
 .card:hover {
-  border-color: #2a3651;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,.15);
+  border-color: var(--accent-color);
+  transform: translateY(-2px);
+  box-shadow: var(--elevated-shadow);
 }
-.card h3 { 
-  margin: 0 0 20px; 
-  font-size: 18px; 
-  color: #ffffff;
+.card h3 {
+  margin: 0 0 20px;
+  font-size: 18px;
+  color: var(--text-color);
   display: flex;
   align-items: center;
   justify-content: space-between;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
+  font-family: var(--font-heading);
 }
 .card h3 button {
   margin-left: 8px;
@@ -507,12 +438,12 @@ button:hover {
 }
 
 /* Inputs */
-label { 
-  display: grid; 
-  gap: 6px; 
-  margin-bottom: 14px; 
-  font-size: 12px; 
-  color: #9fb3d9;
+label {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+  font-size: 12px;
+  color: var(--muted-text);
   font-weight: 500;
 }
 
@@ -557,7 +488,7 @@ input, textarea, select {
 input:focus, textarea:focus, select:focus {
   border-color: #3358ff;
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 textarea { 
@@ -806,22 +737,6 @@ textarea {
   border-bottom-right-radius: 50%;
 }
 
-/* Page number indicator */
-.preview-paper::after {
-  content: 'Page ' counter(page);
-  position: absolute;
-  bottom: 10mm;
-  right: 10mm;
-  font-size: 10px;
-  color: #666;
-  counter-increment: page;
-}
-
-/* Initialize page counter */
-.preview {
-  counter-reset: page;
-}
-
 /* Page break indicator */
 .preview-paper[style*="height: 297mm"]:not(:last-child)::before {
   content: '';
@@ -906,15 +821,16 @@ textarea {
   padding: 8px 12px;
   margin-top: 20px;
   border: none;
-  border-radius: 4px;
-  background: #3358ff;
+  border-radius: 8px;
+  background: var(--accent-color);
   color: #fff;
   font-size: 14px;
   font-weight: 600;
   text-decoration: none;
-  transition: background 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .btn:hover{
-  background: #254edb;
+  background: var(--accent-color-hover);
+  transform: scale(1.02);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,14 @@
-import React, { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useReactToPrint } from 'react-to-print';
 import './App.css';
 
 // Forms
 import ExperienceForm from './sections/experiences';
 import EducationForm from './sections/education';
-import Resume from './sections/resume';
+import ResumePreview from './components/ResumePreview';
 import SkillForm from './sections/skills';
 import ProjectForm from './sections/projects';
+import CollapsibleCard from './components/CollapsibleCard';
 
 // UI
 import SidebarLayout from './components/SidebarLayout';
@@ -41,9 +42,31 @@ function App() {
     documentTitle: 'Resume',
   });
 
+  // Theme
+  const [theme, setTheme] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+
   return (
     <SidebarLayout
-      topbar={<TopBar onPrint={handlePrint} onReset={handleReset} onDefault={handleDefault} />}
+      topbar={
+        <TopBar
+          onPrint={handlePrint}
+          onReset={handleReset}
+          onDefault={handleDefault}
+          onToggleTheme={toggleTheme}
+          theme={theme}
+        />
+      }
       sidebar={
         <>
           <div className="grid grid-2">
@@ -139,8 +162,7 @@ function App() {
           </div>
 
 
-          <div className="card">
-            <h3>Education</h3>
+          <CollapsibleCard title="Education">
             <label className="checkbox-label">
               <input
                 type="checkbox"
@@ -151,31 +173,40 @@ function App() {
               Include GPA
             </label>
             <EducationForm data={data} setData={setData} removeEducation={removeEducation} />
-            <button type="button" className="btn" onClick={addEducation}>Add Education</button>
-          </div>
+            <button type="button" className="btn" onClick={addEducation}>
+              Add Education
+            </button>
+          </CollapsibleCard>
 
-          <div className="card">
-            <h3>Experience</h3>
-            <ExperienceForm data={data} setData={setData} removeExperience={removeExperience} />
-            <button type="button" className="btn" onClick={addExperience}>Add Experience</button>
-          </div>
+          <CollapsibleCard title="Experience">
+            <ExperienceForm
+              data={data}
+              setData={setData}
+              removeExperience={removeExperience}
+            />
+            <button type="button" className="btn" onClick={addExperience}>
+              Add Experience
+            </button>
+          </CollapsibleCard>
 
-          <div className="card">
-            <h3>Skills</h3>
+          <CollapsibleCard title="Skills">
             <SkillForm data={data} setData={setData} removeSkill={removeSkill} />
-            <button type="button" className="btn" onClick={addSkill}>Add Skill</button>
-          </div>
+            <button type="button" className="btn" onClick={addSkill}>
+              Add Skill
+            </button>
+          </CollapsibleCard>
 
-          <div className="card">
-            <h3>Projects</h3>
+          <CollapsibleCard title="Projects">
             <ProjectForm data={data} setData={setData} removeProject={removeProject} />
-            <button type="button" className="btn" onClick={addProject}>Add Project</button>
-          </div>
+            <button type="button" className="btn" onClick={addProject}>
+              Add Project
+            </button>
+          </CollapsibleCard>
 
           <ResumeImprover resumeData={data} setData={setData} />
         </>
       }
-      preview={<div className="preview-container" ref={printRef}><div className="preview-paper"><Resume data={data} /></div></div>}
+      preview={<ResumePreview ref={printRef} data={data} />}
     />
   );
 }

--- a/src/components/AiSuggestions.jsx
+++ b/src/components/AiSuggestions.jsx
@@ -1,250 +1,398 @@
 import { useState, useRef } from 'react';
 import Groq from 'groq-sdk';
 import '../styles/ai-suggestions.css';
+import BeforeAfterSlider from './BeforeAfterSlider';
 
 function AiSuggestions({ resumeData, onSuggestionReceived }) {
   const [suggestions, setSuggestions] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [sectionErrors, setSectionErrors] = useState({
+    summary: null,
+    experiences: null,
+    projects: null,
+    skills: null,
+  });
   const abortControllerRef = useRef(null);
 
-  // Process resume data to extract projects and experiences
-  const extractResumeContent = (data) => {
-    let content = "";
-
-    // Projects
-    content += "\n\nPROJECTS:\n";
+  const extractProjects = (data) => {
+    if (!data?.projects?.project?.length) return '';
+    let content = 'PROJECTS:\n';
     data.projects.project.forEach((proj, i) => {
       content += `${i + 1}. [projId=${proj.id}] ${proj.projname}\n`;
-      (proj.description || []).forEach(d => d?.trim() && (content += `   • ${d}\n`));
+      (proj.description || []).forEach(
+        (d) => d?.trim() && (content += `   • ${d}\n`)
+      );
     });
+    return content.trim();
+  };
 
-    // Experience
-    content += "\n\nEXPERIENCE:\n";
+  const extractExperiences = (data) => {
+    if (!data?.experiences?.jobs?.length) return '';
+    let content = 'EXPERIENCE:\n';
     data.experiences.jobs.forEach((job, i) => {
       content += `${i + 1}. [jobId=${job.id}] ${job.title} at ${job.company}\n`;
-      (job.description || []).forEach(d => d?.trim() && (content += `   • ${d}\n`));
+      (job.description || []).forEach(
+        (d) => d?.trim() && (content += `   • ${d}\n`)
+      );
     });
+    return content.trim();
+  };
 
-    // Extract existing skills
+  const extractSkillsSummary = (data) => {
+    let content = '';
+    if (data?.summary?.trim()) {
+      content += `SUMMARY:\n${data.summary.trim()}\n`;
+    }
     if (data?.skills?.skill?.length) {
-      content += "\n\nCURRENT SKILLS:\n";
-      data.skills.skill.forEach(skill => {
+      content += '\nCURRENT SKILLS:\n';
+      data.skills.skill.forEach((skill) => {
         if (skill.skll?.trim()) content += `• ${skill.skll}\n`;
       });
     }
-
-    return content;
+    return content.trim();
   };
 
-  async function generateImprovedContent() {
-    setIsLoading(true);
-    setSuggestions(null);
-    setError(null);
+  const sanitizeBullet = (str) =>
+    (str || '')
+      .replace(/[\n\r]+/g, ' ')
+      .replace(/["\\]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
 
-    // Abort controller
-    abortControllerRef.current = new AbortController();
+  const cleanParsed = (raw) => {
+    const result = {
+      summary: [],
+      projects: [],
+      experiences: [],
+      skills: { add: [], replace: [] },
+    };
+    const validActions = ['replace', 'add'];
 
-    try {
-      // Build resume text
-      const resumeContent = extractResumeContent(resumeData);
-      if (!resumeContent) {
-        setError("No project or experience data found to analyze.");
-        setIsLoading(false);
-        return;
-      }
-
-      // Groq client
-      const groq = new Groq({
-        apiKey: import.meta.env.VITE_GROQ_API_KEY,
-        dangerouslyAllowBrowser: true,
+    if (Array.isArray(raw?.summary)) {
+      raw.summary.forEach((s) => {
+        const k = Object.keys(s || {});
+        if (!['old', 'improved', 'action'].every((x) => k.includes(x)) || k.length !== 3)
+          return;
+        const action =
+          validActions.includes(s.action) && s.action === 'replace' && s.old?.trim()
+            ? 'replace'
+            : 'add';
+        result.summary.push({
+          old: action === 'replace' ? s.old : '',
+          improved: sanitizeBullet(s.improved),
+          action,
+        });
       });
-
-      // STRONGER SYSTEM PROMPT
-      const systemPrompt = `
-You are an expert resume assistant.
-Return ONLY a valid JSON object (no prose, no markdown, no code fences).
-
-Use EXACTLY this schema:
-{
-  "projects": [
-    {
-      "id": "projId (from [projId=...] in my text)",
-      "title": "Project title exactly as given",
-      "items": [
-        {
-          "old": "verbatim bullet from my content or empty if new",
-          "improved": "one-line improved bullet",
-          "action": "replace" | "add"
-        }
-      ]
     }
-  ],
-  "experiences": [
-    {
-      "id": "jobId (from [jobId=...] in my text)",
-      "title": "Job title at Company exactly as given",
-      "items": [
-        {
-          "old": "verbatim bullet from my content or empty if new",
-          "improved": "one-line improved bullet",
-          "action": "replace" | "add"
-        }
-      ]
-    }
-  ],
-  "skills": {
-    "add": ["Skill A", "Skill B"],
-    "replace": [
-      { "old": "weak or duplicate skill", "improved": "stronger alternative" }
-    ]
-  }
-}
 
-Hard rules:
-- Each "replace" MUST copy the original bullet EXACTLY in "old"; otherwise use action "add" and set "old" to "".
-- Keep each bullet on ONE line and prefer metrics.
-- No trailing commas, no smart quotes, no comments.
-- If nothing to improve, return empty arrays.
-`.trim();
-
-      const userPrompt = `
-Analyze my resume content and produce JSON in the schema above.
-
-RESUME CONTENT:
-${resumeContent}
-`.trim();
-
-      let res;
-      try {
-        res = await groq.chat.completions.create(
-          {
-            model: "llama-3.3-70b-versatile",
-            messages: [
-              { role: "system", content: systemPrompt },
-              { role: "user", content: userPrompt },
-            ],
-            temperature: 0.1,
-            top_p: 1,
-            max_tokens: 1800,
-            stream: false,
-            // JSON mode
-            response_format: { type: "json_object" },
-          },
-          { signal: abortControllerRef.current?.signal }
-        );
-      } catch (apiErr) {
-        // If Groq returns json_validate_failed, show the raw generation to help fix prompt
-        const fail = apiErr?.error?.failed_generation;
-        if (fail) {
-          setError(
-            "Model returned malformed JSON. Showing raw output so you can inspect:\n\n" +
-            fail
-          );
-        } else {
-          setError(apiErr.message || "Request failed.");
-        }
-        setIsLoading(false);
-        return;
-      }
-
-      const text = res?.choices?.[0]?.message?.content ?? "";
-
-      // --- Robust parse with a tiny repair fallback ---
-      const parsed = safeParseJson(text);
-      if (!parsed) {
-        setError("Model did not return valid JSON. Please try again.");
-        setIsLoading(false);
-        return;
-      }
-
-      const expItems = parsed.experiences?.flatMap(exp =>
-        exp.items.map((item, index) => ({
-          key: `exp-${exp.id}-${index}`,
-          section: 'experiences',
-          parentId: exp.id,
-          context: exp.title,
-          old: item.old,
-          improved: item.improved,
-          removing: false,
-        }))
-      ) || [];
-      const projItems = parsed.projects?.flatMap(proj =>
-        proj.items.map((item, index) => ({
-          key: `proj-${proj.id}-${index}`,
-          section: 'projects',
-          parentId: proj.id,
-          context: proj.title,
-          old: item.old,
-          improved: item.improved,
-          removing: false,
-        }))
-      ) || [];
-      const skillItems = [
-        ...(parsed.skills?.add?.map((skill, index) => ({
-          key: `skill-add-${index}`,
-          section: 'skills',
-          old: '',
-          improved: skill,
-          removing: false,
-        })) || []),
-        ...(parsed.skills?.replace?.map((skill, index) => ({
-          key: `skill-replace-${index}`,
-          section: 'skills',
-          old: skill.old,
-          improved: skill.improved,
-          removing: false,
-        })) || []),
-      ];
-      setSuggestions({
-        experiences: expItems,
-        projects: projItems,
-        skills: skillItems,
+    if (Array.isArray(raw?.projects)) {
+      raw.projects.forEach((p) => {
+        const keys = Object.keys(p || {});
+        if (!['id', 'title', 'items'].every((k) => keys.includes(k)) || keys.length !== 3)
+          return;
+        const items = Array.isArray(p.items)
+          ? p.items.reduce((acc, it) => {
+              const k = Object.keys(it || {});
+              if (
+                !['old', 'improved', 'action'].every((x) => k.includes(x)) ||
+                k.length !== 3
+              )
+                return acc;
+              if (!validActions.includes(it.action)) return acc;
+              const action = it.action === 'replace' && it.old?.trim() ? 'replace' : 'add';
+              acc.push({
+                old: action === 'replace' ? it.old : '',
+                improved: sanitizeBullet(it.improved),
+                action,
+              });
+              return acc;
+            }, [])
+          : [];
+        if (items.length) result.projects.push({ id: p.id, title: p.title, items });
       });
-    } catch (err) {
-      if (err.name !== "AbortError") {
-        setError(err.message || "Failed to generate improvements.");
-      }
-    } finally {
-      setIsLoading(false);
     }
-  }
 
-  /** Try strict JSON.parse; if it fails, trim to the outermost braces and parse again. */
-  function safeParseJson(s) {
+    if (Array.isArray(raw?.experiences)) {
+      raw.experiences.forEach((p) => {
+        const keys = Object.keys(p || {});
+        if (!['id', 'title', 'items'].every((k) => keys.includes(k)) || keys.length !== 3)
+          return;
+        const items = Array.isArray(p.items)
+          ? p.items.reduce((acc, it) => {
+              const k = Object.keys(it || {});
+              if (
+                !['old', 'improved', 'action'].every((x) => k.includes(x)) ||
+                k.length !== 3
+              )
+                return acc;
+              if (!validActions.includes(it.action)) return acc;
+              const action = it.action === 'replace' && it.old?.trim() ? 'replace' : 'add';
+              acc.push({
+                old: action === 'replace' ? it.old : '',
+                improved: sanitizeBullet(it.improved),
+                action,
+              });
+              return acc;
+            }, [])
+          : [];
+        if (items.length) result.experiences.push({ id: p.id, title: p.title, items });
+      });
+    }
+
+    const skills = raw?.skills || {};
+    if (Array.isArray(skills.add)) {
+      skills.add.forEach((s) => {
+        if (typeof s === 'string' && s.trim())
+          result.skills.add.push(sanitizeBullet(s));
+      });
+    }
+    if (Array.isArray(skills.replace)) {
+      skills.replace.forEach((s) => {
+        const k = Object.keys(s || {});
+        if (!['old', 'improved'].every((x) => k.includes(x)) || k.length !== 2) return;
+        result.skills.replace.push({
+          old: s.old,
+          improved: sanitizeBullet(s.improved),
+        });
+      });
+    }
+    return result;
+  };
+
+  const safeParseJson = (s) => {
     try {
       return JSON.parse(s);
     } catch {
-      // Remove any leading/trailing noise (e.g., stray backticks or extra braces)
-      const start = s.indexOf("{");
-      const end = s.lastIndexOf("}");
+      const start = s.indexOf('{');
+      const end = s.lastIndexOf('}');
       if (start !== -1 && end !== -1 && end > start) {
-        const trimmed = s.slice(start, end + 1);
         try {
-          return JSON.parse(trimmed);
+          return JSON.parse(s.slice(start, end + 1));
         } catch {
           return null;
         }
       }
       return null;
     }
+  };
+
+  const fetchWithRetry = async (fn, retries = 1) => {
+    let lastErr;
+    for (let i = 0; i <= retries; i++) {
+      try {
+        return await fn();
+      } catch (e) {
+        lastErr = e;
+      }
+    }
+    throw lastErr;
+  };
+
+  async function generateImprovedContent() {
+    setIsLoading(true);
+    setSuggestions(null);
+    setError(null);
+    setSectionErrors({ summary: null, experiences: null, projects: null, skills: null });
+
+    abortControllerRef.current = new AbortController();
+
+    const groq = new Groq({
+      apiKey: import.meta.env.VITE_GROQ_API_KEY,
+      dangerouslyAllowBrowser: true,
+    });
+
+    const combined = {
+      summary: [],
+      projects: [],
+      experiences: [],
+      skills: { add: [], replace: [] },
+    };
+    const errors = {};
+
+    const skillsContent = extractSkillsSummary(resumeData);
+    const expContent = extractExperiences(resumeData);
+    const projContent = extractProjects(resumeData);
+
+    const controller = abortControllerRef.current;
+
+    const request = async (systemPrompt, userPrompt) => {
+      const res = await groq.chat.completions.create(
+        {
+          model: 'llama-3.3-70b-versatile',
+          messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+          ],
+          temperature: 0.1,
+          top_p: 1,
+          max_tokens: 800,
+          stream: false,
+          response_format: { type: 'json_object' },
+        },
+        { signal: controller.signal }
+      );
+      return res?.choices?.[0]?.message?.content ?? '';
+    };
+
+    const handleSection = async (section, content) => {
+      if (!content) return;
+      const prompts = {
+        skills: `You are an expert resume assistant. Return ONLY JSON: {"summary":[{"old":"","improved":"","action":"replace"|"add"}],"skills":{"add":[""],"replace":[{"old":"","improved":""}]}}`,
+        experiences: `You are an expert resume assistant. Return ONLY JSON: {"experiences":[{"id":"","title":"","items":[{"old":"","improved":"","action":"replace"|"add"}]}]}`,
+        projects: `You are an expert resume assistant. Return ONLY JSON: {"projects":[{"id":"","title":"","items":[{"old":"","improved":"","action":"replace"|"add"}]}]}`,
+      };
+      const system = prompts[section];
+      const user = `Analyze the following content and provide suggestions.\n\n${content}`.trim();
+      let text;
+      try {
+        text = await fetchWithRetry(() => request(system, user));
+      } catch (e) {
+        errors[section] = e.message || 'Request failed.';
+        return;
+      }
+      const parsed = safeParseJson(text);
+      if (!parsed) return;
+      const cleaned = cleanParsed(parsed);
+      combined.summary.push(...cleaned.summary);
+      combined.projects.push(...cleaned.projects);
+      combined.experiences.push(...cleaned.experiences);
+      combined.skills.add.push(...cleaned.skills.add);
+      combined.skills.replace.push(...cleaned.skills.replace);
+    };
+
+    try {
+      await Promise.all([
+        handleSection('skills', skillsContent),
+        handleSection('experiences', expContent),
+        handleSection('projects', projContent),
+      ]);
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        setError(err.message || 'Failed to generate improvements.');
+      }
+      setIsLoading(false);
+      return;
+    }
+
+    setSectionErrors(errors);
+
+    const seenExp = new Set();
+    const expItems = [];
+    combined.experiences.forEach((exp) => {
+      exp.items.forEach((item, idx) => {
+        const key = `${exp.id}:${item.improved}`;
+        if (seenExp.has(key)) return;
+        seenExp.add(key);
+        expItems.push({
+          key: `exp-${exp.id}-${idx}`,
+          section: 'experiences',
+          parentId: exp.id,
+          context: exp.title,
+          old: item.old,
+          improved: item.improved,
+          removing: false,
+        });
+      });
+    });
+
+    const seenProj = new Set();
+    const projItems = [];
+    combined.projects.forEach((proj) => {
+      proj.items.forEach((item, idx) => {
+        const key = `${proj.id}:${item.improved}`;
+        if (seenProj.has(key)) return;
+        seenProj.add(key);
+        projItems.push({
+          key: `proj-${proj.id}-${idx}`,
+          section: 'projects',
+          parentId: proj.id,
+          context: proj.title,
+          old: item.old,
+          improved: item.improved,
+          removing: false,
+        });
+      });
+    });
+
+    const summaryItems = combined.summary.map((item, idx) => ({
+      key: `summary-${idx}`,
+      section: 'summary',
+      parentId: 'summary',
+      context: 'Summary',
+      old: item.old,
+      improved: item.improved,
+      removing: false,
+    }));
+
+    const skillAddSeen = new Set();
+    const skillReplaceSeen = new Set();
+    const skillItems = [
+      ...combined.skills.add
+        .filter((s) => {
+          const key = `add:${s}`;
+          if (skillAddSeen.has(key)) return false;
+          skillAddSeen.add(key);
+          return true;
+        })
+        .map((skill, index) => ({
+          key: `skill-add-${index}`,
+          section: 'skills',
+          old: '',
+          improved: skill,
+          removing: false,
+        })),
+      ...combined.skills.replace
+        .filter((s) => {
+          const key = `rep:${s.old}:${s.improved}`;
+          if (skillReplaceSeen.has(key)) return false;
+          skillReplaceSeen.add(key);
+          return true;
+        })
+        .map((skill, index) => ({
+          key: `skill-replace-${index}`,
+          section: 'skills',
+          old: skill.old,
+          improved: skill.improved,
+          removing: false,
+        })),
+    ];
+
+    if (
+      summaryItems.length === 0 &&
+      expItems.length === 0 &&
+      projItems.length === 0 &&
+      skillItems.length === 0
+    ) {
+      setError('No valid suggestions returned.');
+      setIsLoading(false);
+      return;
+    }
+
+    setSuggestions({
+      summary: summaryItems,
+      experiences: expItems,
+      projects: projItems,
+      skills: skillItems,
+    });
+    setIsLoading(false);
   }
 
   const triggerRemove = (category, key) => {
-    setSuggestions(prev => {
+    setSuggestions((prev) => {
       if (!prev) return prev;
       const updated = {
         ...prev,
-        [category]: prev[category].map(item =>
+        [category]: prev[category].map((item) =>
           item.key === key ? { ...item, removing: true } : item
         ),
       };
       setTimeout(() => {
-        setSuggestions(curr => {
+        setSuggestions((curr) => {
           if (!curr) return curr;
           return {
             ...curr,
-            [category]: curr[category].filter(item => item.key !== key),
+            [category]: curr[category].filter((item) => item.key !== key),
           };
         });
       }, 200);
@@ -302,45 +450,143 @@ ${resumeContent}
 
         {suggestions && !isLoading && (
           <div className="suggestion-content">
-            {suggestions.experiences.map(item => (
-              <div key={item.key} className={`suggestion-card ${item.removing ? 'fade-out' : ''}`}>
-                <button className="remove-btn" onClick={() => triggerRemove('experiences', item.key)}>×</button>
-                {item.context && <h5>{item.context}</h5>}
-                {item.old && <p className="old"><strong>Old:</strong> {item.old}</p>}
-                <p className="improved"><strong>Improved:</strong> {item.improved}</p>
-                <div className="row gap-s">
-                  <button className="btn" onClick={() => handleAction('replace', item)}>Replace</button>
-                  <button className="btn" onClick={() => handleAction('add', item)}>Add</button>
+            {sectionErrors.summary && (
+              <div className="error">Summary: {sectionErrors.summary}</div>
+            )}
+            {suggestions.summary.map((item) => (
+              <div
+                key={item.key}
+                className={`suggestion-card ${item.removing ? 'fade-out' : ''}`}
+              >
+                <button
+                  className="dismiss-btn"
+                  onClick={() => triggerRemove('summary', item.key)}
+                >
+                  ×
+                </button>
+                {item.context && <h5 className="s-card-title">{item.context}</h5>}
+                <BeforeAfterSlider before={item.old} after={item.improved} />
+                <div className="actions">
+                  <button
+                    className="replace-btn"
+                    onClick={() => handleAction('replace', item)}
+                  >
+                    Replace
+                  </button>
+                  <button
+                    className="add-btn"
+                    onClick={() => handleAction('add', item)}
+                  >
+                    Add
+                  </button>
                 </div>
               </div>
             ))}
-            {suggestions.projects.map(item => (
-              <div key={item.key} className={`suggestion-card ${item.removing ? 'fade-out' : ''}`}>
-                <button className="remove-btn" onClick={() => triggerRemove('projects', item.key)}>×</button>
-                {item.context && <h5>{item.context}</h5>}
-                {item.old && <p className="old"><strong>Old:</strong> {item.old}</p>}
-                <p className="improved"><strong>Improved:</strong> {item.improved}</p>
-                <div className="row gap-s">
-                  <button className="btn" onClick={() => handleAction('replace', item)}>Replace</button>
-                  <button className="btn" onClick={() => handleAction('add', item)}>Add</button>
+
+            {sectionErrors.experiences && (
+              <div className="error">Experiences: {sectionErrors.experiences}</div>
+            )}
+            {suggestions.experiences.map((item) => (
+              <div
+                key={item.key}
+                className={`suggestion-card ${item.removing ? 'fade-out' : ''}`}
+              >
+                <button
+                  className="dismiss-btn"
+                  onClick={() => triggerRemove('experiences', item.key)}
+                >
+                  ×
+                </button>
+                {item.context && <h5 className="s-card-title">{item.context}</h5>}
+                <BeforeAfterSlider before={item.old} after={item.improved} />
+                <div className="actions">
+                  <button
+                    className="replace-btn"
+                    onClick={() => handleAction('replace', item)}
+                  >
+                    Replace
+                  </button>
+                  <button
+                    className="add-btn"
+                    onClick={() => handleAction('add', item)}
+                  >
+                    Add
+                  </button>
                 </div>
               </div>
             ))}
+
+            {sectionErrors.projects && (
+              <div className="error">Projects: {sectionErrors.projects}</div>
+            )}
+            {suggestions.projects.map((item) => (
+              <div
+                key={item.key}
+                className={`suggestion-card ${item.removing ? 'fade-out' : ''}`}
+              >
+                <button
+                  className="dismiss-btn"
+                  onClick={() => triggerRemove('projects', item.key)}
+                >
+                  ×
+                </button>
+                {item.context && <h5 className="s-card-title">{item.context}</h5>}
+                <BeforeAfterSlider before={item.old} after={item.improved} />
+                <div className="actions">
+                  <button
+                    className="replace-btn"
+                    onClick={() => handleAction('replace', item)}
+                  >
+                    Replace
+                  </button>
+                  <button
+                    className="add-btn"
+                    onClick={() => handleAction('add', item)}
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+            ))}
+
+            {sectionErrors.skills && (
+              <div className="error">Skills: {sectionErrors.skills}</div>
+            )}
             {suggestions.skills.length > 0 && (
               <div className="skill-suggestions">
-                {suggestions.skills.map(item => (
-                  <div key={item.key} className={`skill-chip ${item.removing ? 'fade-out' : ''}`}>
-                    <button className="remove-btn" onClick={() => triggerRemove('skills', item.key)}>×</button>
+                {suggestions.skills.map((item) => (
+                  <div
+                    key={item.key}
+                    className={`skill-chip ${item.removing ? 'fade-out' : ''}`}
+                  >
+                    <button
+                      className="dismiss-btn"
+                      onClick={() => triggerRemove('skills', item.key)}
+                    >
+                      ×
+                    </button>
                     {item.old ? (
-                      <span><strong>{item.old}</strong> → {item.improved}</span>
+                      <span>
+                        <strong>{item.old}</strong> → {item.improved}
+                      </span>
                     ) : (
                       <span>{item.improved}</span>
                     )}
-                    <div className="row gap-s">
+                    <div className="actions">
                       {item.old && (
-                        <button className="btn" onClick={() => handleAction('replace', item)}>Replace</button>
+                        <button
+                          className="replace-btn"
+                          onClick={() => handleAction('replace', item)}
+                        >
+                          Replace
+                        </button>
                       )}
-                      <button className="btn" onClick={() => handleAction('add', item)}>Add</button>
+                      <button
+                        className="add-btn"
+                        onClick={() => handleAction('add', item)}
+                      >
+                        Add
+                      </button>
                     </div>
                   </div>
                 ))}
@@ -352,7 +598,7 @@ ${resumeContent}
         {!isLoading && !error && !suggestions && (
           <p className="hint">
             Click &quot;Generate Improvements&quot; to get AI-powered suggestions for your projects,
-            experience descriptions, and recommended skills to add to your resume.
+            experience descriptions, summary, and recommended skills to add to your resume.
           </p>
         )}
       </div>
@@ -361,3 +607,4 @@ ${resumeContent}
 }
 
 export default AiSuggestions;
+

--- a/src/components/BeforeAfterSlider.jsx
+++ b/src/components/BeforeAfterSlider.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import '../styles/ai-suggestions.css';
+
+export default function BeforeAfterSlider({ before = '', after = '' }) {
+  const [pos, setPos] = useState(50);
+
+  return (
+    <div className="ba-slider">
+      {before && (
+        <div className="ba-before" style={{ width: `${pos}%` }}>
+          <p>{before}</p>
+        </div>
+      )}
+      <div className="ba-after">
+        <p>{after}</p>
+      </div>
+      {before && <div className="ba-divider" style={{ left: `${pos}%` }} />}
+      {before && (
+        <input
+          className="ba-input"
+          type="range"
+          min="0"
+          max="100"
+          value={pos}
+          onChange={(e) => setPos(e.target.value)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/CollapsibleCard.jsx
+++ b/src/components/CollapsibleCard.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import '../styles/forms.css';
+
+export default function CollapsibleCard({ title, children, defaultOpen = true }) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className={`card collapsible ${open ? 'open' : 'closed'}`}>
+      <button
+        type="button"
+        className="collapse-toggle"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+      >
+        <h3>{title}</h3>
+        <FontAwesomeIcon icon={open ? faChevronUp : faChevronDown} />
+      </button>
+      <div className="card-body" style={{ display: open ? 'block' : 'none' }}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResumeImprover.jsx
+++ b/src/components/ResumeImprover.jsx
@@ -36,6 +36,13 @@ function ResumeImprover({ resumeData, setData }) {
             skill: [...prev.skills.skill, { id: uuidv4(), skll: suggestion.new }],
           },
         }));
+      } else if (suggestion.section === 'summary') {
+        setData(prev => ({
+          ...prev,
+          summary: prev.summary
+            ? `${prev.summary} ${suggestion.new}`
+            : suggestion.new,
+        }));
       }
     } else if (suggestion.type === 'replace') {
       if (suggestion.section === 'experiences') {
@@ -81,6 +88,11 @@ function ResumeImprover({ resumeData, setData }) {
               s.skll === suggestion.old ? { ...s, skll: suggestion.new } : s
             ),
           },
+        }));
+      } else if (suggestion.section === 'summary') {
+        setData(prev => ({
+          ...prev,
+          summary: suggestion.new,
         }));
       }
     }

--- a/src/components/ResumePreview.jsx
+++ b/src/components/ResumePreview.jsx
@@ -1,0 +1,124 @@
+/* eslint-disable react/prop-types */
+import { forwardRef, useEffect, useRef, useState } from 'react';
+import Resume from '../sections/resume';
+
+// Convert millimeters to pixels (96 DPI)
+const mmToPx = (mm) => (mm * 96) / 25.4;
+
+// Available content height inside the page (excluding padding and footer space)
+const PAGE_CONTENT_HEIGHT = mmToPx(297 - 25 - 35); // 237mm
+
+// Helper to measure a node's outer height including margins
+const getOuterHeight = (node) => {
+  const style = window.getComputedStyle(node);
+  return (
+    node.offsetHeight +
+    parseFloat(style.marginTop || 0) +
+    parseFloat(style.marginBottom || 0)
+  );
+};
+
+const ResumePreview = forwardRef(function ResumePreview({ data }, ref) {
+  const measureRef = useRef(null);
+  const containerRef = useRef(null);
+  const [pages, setPages] = useState([]);
+
+  useEffect(() => {
+    const container = measureRef.current;
+    if (!container) return;
+
+    const newPages = [];
+    let currentPage = [];
+    let currentHeight = 0;
+
+    const pushPage = () => {
+      if (currentPage.length) {
+        newPages.push(currentPage);
+        currentPage = [];
+        currentHeight = 0;
+      }
+    };
+
+    const addNode = (node) => {
+      currentPage.push(node.cloneNode(true));
+      currentHeight += getOuterHeight(node);
+    };
+
+    // Top block (name + contact)
+    const top = container.querySelector('.top');
+    if (top) {
+      if (getOuterHeight(top) > PAGE_CONTENT_HEIGHT && currentPage.length) {
+        pushPage();
+      }
+      addNode(top);
+    }
+
+    // Process each resume section
+    container.querySelectorAll('.section').forEach((section) => {
+      const header = section.querySelector('.section-title');
+      const entries = Array.from(section.children).filter(
+        (child) => child !== header
+      );
+
+      entries.forEach((entry, index) => {
+        const entryHeight = getOuterHeight(entry);
+
+        if (index === 0) {
+          const headerHeight = getOuterHeight(header);
+          if (
+            currentHeight + headerHeight + entryHeight > PAGE_CONTENT_HEIGHT &&
+            currentPage.length
+          ) {
+            pushPage();
+          }
+
+          addNode(header);
+        } else if (
+          currentHeight + entryHeight > PAGE_CONTENT_HEIGHT &&
+          currentPage.length
+        ) {
+          pushPage();
+        }
+
+        addNode(entry);
+      });
+    });
+
+    pushPage();
+
+    const htmlPages = newPages.map((nodes) =>
+      nodes.map((n) => n.outerHTML).join('')
+    );
+
+    setPages(htmlPages);
+
+    if (containerRef.current) {
+      containerRef.current.classList.add('flash');
+      setTimeout(() => containerRef.current && containerRef.current.classList.remove('flash'), 300);
+    }
+  }, [data]);
+
+  return (
+    <>
+      {/* Hidden container for measuring content */}
+      <div ref={measureRef} className="preview-measure">
+        <Resume data={data} />
+      </div>
+
+      <div className="preview-container" ref={(el) => { containerRef.current = el; if (typeof ref === 'function') ref(el); else if (ref) ref.current = el; }}>
+        {pages.map((html, i) => (
+          <div
+            key={i}
+            className="preview-paper"
+            data-total={pages.length}
+          >
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+});
+
+export default ResumePreview;
+

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,13 +1,21 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPrint, faRotateLeft, faStar } from '@fortawesome/free-solid-svg-icons';
+import { faPrint, faRotateLeft, faStar, faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
 
-export default function TopBar({ onPrint, onReset, onDefault }) {
+export default function TopBar({ onPrint, onReset, onDefault, onToggleTheme, theme }) {
   return (
     <div className="topbar">
       <div className="left">
         <h2>Resume Builder</h2>
       </div>
       <div className="right">
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={onToggleTheme}
+          title="Toggle theme"
+        >
+          <FontAwesomeIcon icon={theme === 'dark' ? faSun : faMoon} />
+        </button>
         <button type="button" className="btn ghost" onClick={onDefault} title="Load sample data">
           <FontAwesomeIcon icon={faStar} /> Sample
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,39 +1,81 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Lora:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&family=Source+Sans+Pro:wght@400;600&display=swap');
+
+/*
+  Design system tokens for light and dark themes. Tokens are defined once and
+  reused throughout component styles so switching themes only swaps values.
+*/
 
 :root {
-  /* Color Palette */
-  --base-color: #1A202C; /* Deep Navy */
-  --accent-color: #008080; /* Teal */
-  --text-color: #E2E8F0;
-  --card-bg: #2D3748;
-  --border-color: #4A5568;
-  --subtle-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  /* Base tokens */
+  --surface: #ffffff;
+  --surface-subtle: #f7f9fc;
+  --text-primary: #1c1e21;
+  --text-secondary: #6b7280;
+  --line: #e5e7eb;
+  --brand: #3358ff;
+  --brand-tint: rgba(51, 88, 255, 0.1);
+  --success: #3bcf85;
+  --danger: #ff4d4f;
+  --control-bg: #ffffff;
+  --control-border: #d1d5db;
+  --focus-ring: rgba(51, 88, 255, 0.35);
+
+  /* Shadows */
+  --subtle-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  --elevated-shadow: 0 8px 16px rgba(0,0,0,0.15);
 
   /* Typography */
   --font-heading: 'Poppins', sans-serif;
-  --font-body: 'Lora', serif;
+  --font-body: 'Source Sans Pro', sans-serif;
+
+  /* Legacy variable aliases for existing styles */
+  --base-color: var(--surface-subtle);
+  --surface-color: var(--surface);
+  --accent-color: var(--brand);
+  --accent-color-hover: #5a70ff;
+  --text-color: var(--text-primary);
+  --muted-text: var(--text-secondary);
+  --card-bg: var(--surface);
+  --border-color: var(--line);
+  --primary-blue: var(--brand);
+  --primary-blue-light: var(--brand-tint);
+  --light-bg: var(--surface-subtle);
 
   font-family: var(--font-body);
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: var(--text-color);
-  background-color: var(--base-color);
+  color: var(--text-primary);
+  background-color: var(--surface-subtle);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+[data-theme='dark'] {
+  --surface: #0f131a;
+  --surface-subtle: #0b1017;
+  --text-primary: #e9f0ff;
+  --text-secondary: #9fb3d9;
+  --line: #1c2330;
+  --brand-tint: rgba(51, 88, 255, 0.15);
+  --control-bg: #0e1520;
+  --control-border: #243146;
+  background-color: var(--surface-subtle);
+  color: var(--text-primary);
 }
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--accent-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--accent-color-hover);
 }
 
 body {
@@ -49,23 +91,41 @@ h1 {
   line-height: 1.1;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+}
+
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: none;
   padding: 0.6em 1.2em;
   font-size: 1em;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--accent-color);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: var(--accent-color-hover);
+  transform: scale(1.02);
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: none;
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (prefers-color-scheme: light) {
@@ -74,9 +134,9 @@ button:focus-visible {
     background-color: #ffffff;
   }
   a:hover {
-    color: #747bff;
+    color: var(--accent-color-hover);
   }
   button {
-    background-color: #f9f9f9;
+    background-color: var(--accent-color);
   }
 }

--- a/src/sections/resume.css
+++ b/src/sections/resume.css
@@ -38,6 +38,8 @@ body {
 
 .education-item, .experience-item, .project-item {
     margin-bottom: 0.5em;
+    break-inside: avoid;
+    page-break-inside: avoid;
 }
 
 .education-header, .experience-header, .project-header, .education-details, .experience-details, .project-details {
@@ -56,6 +58,8 @@ body {
 
 .skills-list {
     columns: 2;
+    break-inside: avoid;
+    page-break-inside: avoid;
 }
 
 .skill-item {

--- a/src/styles/ai-suggestions.css
+++ b/src/styles/ai-suggestions.css
@@ -1,15 +1,5 @@
 /* AI Suggestions Styling */
 
-.ai-suggestion {
-  background: #0b1017; 
-  border: 1px solid #1d2737; 
-  border-radius: 14px; 
-  padding: 20px; 
-  margin: 24px 0;
-  width: 100%;
-  max-width: 480px;
-}
-
 .card-header {
   display: flex;
   justify-content: space-between;
@@ -17,15 +7,9 @@
   margin-bottom: 16px;
 }
 
-.card-title {
-  margin: 0;
-  font-size: 18px;
-  color: #ffffff;
-  font-weight: 600;
-}
-
 .card-body {
   min-height: 100px;
+  width: 100%;
 }
 
 .row {
@@ -49,15 +33,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: #9fb3d9;
+  color: var(--muted-text);
   font-size: 14px;
 }
 
 .spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid #3e4f70;
-  border-top-color: #3358ff;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--accent-color);
   border-radius: 50%;
   animation: spin .8s linear infinite;
 }
@@ -78,21 +62,17 @@
 }
 
 .hint {
-  color: #88a0c9;
+  color: var(--muted-text);
   font-size: 14px;
   margin: 8px 0;
 }
 
-.suggestion-content {
-  margin-top: 12px;
-}
-
 .suggestion-pre {
-  background: #0e1520;
-  border: 1px solid #243146;
+  background: var(--surface-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 16px;
-  color: #e9f0ff;
+  color: var(--text-color);
   font-family: inherit;
   font-size: 14px;
   line-height: 1.5;
@@ -103,18 +83,148 @@
   overflow-y: auto;
 }
 
+.suggestion-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 12px;
+}
+
 .suggestion-card {
   position: relative;
-  background: #0e1520;
-  border: 1px solid #243146;
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 12px;
-  transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  color: var(--text-color);
 }
 
 .suggestion-card:hover {
-  border-color: #3358ff;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.dismiss-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  color: var(--muted-text);
+  cursor: pointer;
+}
+
+.dismiss-btn:hover {
+  color: var(--accent-color);
+}
+
+.s-card-title {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 600;
+  font-family: var(--font-heading);
+  color: var(--text-color);
+}
+
+.ba-slider {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  margin: 8px 0;
+}
+
+.ba-before,
+.ba-after {
+  padding: 8px 12px;
+  line-height: 1.4;
+}
+
+.ba-after {
+  background: var(--primary-blue-light);
+  color: var(--text-color);
+}
+
+.ba-before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: var(--light-bg);
+  color: var(--muted-text);
+  overflow: hidden;
+  transition: width 0.2s ease-in-out;
+}
+
+.ba-divider {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
+  background: var(--accent-color);
+  transform: translateX(-1px);
+}
+
+.ba-divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent-color);
+  border: 2px solid #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.ba-input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: ew-resize;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.replace-btn,
+.add-btn {
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 8px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.replace-btn {
+  background: var(--accent-color);
+  border: none;
+  color: #fff;
+}
+
+.replace-btn:hover {
+  background: var(--accent-color-hover);
+}
+
+.add-btn {
+  background: transparent;
+  border: 1px solid var(--accent-color);
+  color: var(--accent-color);
+}
+
+.add-btn:hover {
+  background: var(--accent-color);
+  color: #fff;
 }
 
 .skill-suggestions {
@@ -129,37 +239,22 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: #0e1520;
-  border: 1px solid #243146;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
   padding: 4px 8px;
   transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  color: var(--text-color);
 }
 
 .skill-chip:hover {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
 }
 
-.remove-btn {
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  background: transparent;
-  border: none;
-  color: #9fb3d9;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 1;
-}
-
-.remove-btn:hover {
-  color: #ffffff;
-}
-
-.skill-chip .remove-btn {
+.skill-chip .dismiss-btn {
   top: -6px;
   right: -6px;
-  background: #243146;
+  background: var(--border-color);
   border-radius: 50%;
   width: 16px;
   height: 16px;
@@ -167,9 +262,11 @@
   align-items: center;
   justify-content: center;
   font-size: 12px;
+  color: var(--muted-text);
 }
 
 .fade-out {
   opacity: 0;
-  transform: scale(0.95);
+  transform: translateY(-8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }

--- a/src/styles/forms.css
+++ b/src/styles/forms.css
@@ -19,7 +19,7 @@
 
 .description-item:before {
   content: "•";
-  color: #3358ff;
+  color: var(--accent-color);
   font-size: 1.2em;
   position: absolute;
   left: 8px;
@@ -44,16 +44,16 @@
   font-size: 13px;
   white-space: pre-wrap;
   margin-right: 8px;
-  background-color: #0e1520;
-  border: 1px solid #243146;
-  border-radius: 10px;
-  color: #e9f0ff;
+  background-color: var(--surface-color);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-color);
 }
 
 .description-item textarea:focus {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .description-item .bullet-delete {
@@ -88,9 +88,9 @@
 /* Add Bullet Button */
 .add-bullet-btn {
   margin-top: 12px;
-  background: rgba(51, 88, 255, 0.1);
-  color: #3358ff;
-  border: 1px solid rgba(51, 88, 255, 0.2);
+  background: var(--brand-tint);
+  color: var(--brand);
+  border: 1px solid var(--brand);
   padding: 8px 16px;
   border-radius: 8px;
   font-size: 13px;
@@ -99,7 +99,7 @@
 }
 
 .add-bullet-btn:hover {
-  background: rgba(51, 88, 255, 0.15);
+  background: rgba(51,88,255,0.15);
   transform: translateY(-1px);
 }
 
@@ -136,50 +136,50 @@
 }
 
 /* Form Inputs */
-input, textarea, select { 
+input, textarea, select {
   width: calc(100% - 28px);
   max-width: 400px;
   min-width: 200px;
-  padding: 12px 14px; 
-  border-radius: 10px; 
-  border: 1px solid #243146; 
-  background: #0e1520; 
-  color: #e9f0ff; 
+  padding: 12px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  color: var(--text-color);
   font-size: 13px;
   transition: all 0.2s ease;
   box-sizing: border-box;
 }
 
 input:focus, textarea:focus, select:focus {
-  border-color: #3358ff;
+  border-color: var(--accent-color);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(51,88,255,.15);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
-label { 
-  display: grid; 
-  gap: 6px; 
-  margin-bottom: 12px; 
-  font-size: 12px; 
-  color: #9fb3d9;
+label {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: var(--muted-text);
   font-weight: 500;
 }
 
 /* Add Project/Experience Button */
 .add-new-btn {
   margin-top: 16px;
-  background: #3358ff;
-  color: white;
+  background: var(--accent-color);
+  color: #fff;
   border: none;
   padding: 10px 16px;
   border-radius: 8px;
   font-size: 14px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .add-new-btn:hover {
-  background: #4066ff;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(51,88,255,.25);
+  background: var(--accent-color-hover);
+  transform: scale(1.02);
+  box-shadow: var(--subtle-shadow);
 }

--- a/src/styles/preview.css
+++ b/src/styles/preview.css
@@ -3,42 +3,80 @@
 .preview-container {
     overflow-y: auto;
     height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+    counter-reset: page; /* Initialize page counter */
 }
 
+.preview-container.flash .preview-paper {
+  animation: flash 0.3s ease;
+}
+
+
+.preview-measure {
+  position: absolute;
+  visibility: hidden;
+  top: 0;
+  left: -9999px;
+  width: 210mm;
+  padding: 25mm 25mm 35mm;
+  box-sizing: border-box;
+}
+
+/* legacy container retained for layout wrappers */
 .preview {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 40px;
-  background: #f0f2f5;
+  background: var(--base-color);
   overflow-x: hidden;
   gap: 40px; /* Space between pages */
   box-sizing: border-box;
-  counter-reset: page; /* Initialize page counter */
 }
 
 a {
     color: black;
 }
 
-.preview-paper { 
-  width: 210mm; 
-  height: 297mm; 
-  padding: 25mm 25mm;
-  background: #fff; 
-  color: #111; 
-  border-radius: 12px; 
-  box-shadow: 0 4px 24px rgba(0,0,0,.12),
-              0 12px 48px rgba(0,0,0,.12); 
+.preview-paper {
+  width: 210mm;
+  height: 297mm;
+  padding: 25mm 25mm 35mm;
+  background: #fff;
+  color: #111;
+  border-radius: 12px;
+  box-shadow: var(--subtle-shadow);
+  font-family: var(--font-body);
   position: relative;
   overflow: visible;
   page-break-after: always;
+  break-after: page;
   box-sizing: border-box;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+@keyframes flash {
+  from { opacity: 0.3; }
+  to { opacity: 1; }
+}
+
+.preview-paper:last-child {
+  page-break-after: avoid;
+  break-after: avoid;
+}
+
+.preview-paper:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--elevated-shadow);
 }
 
 /* Page number indicator */
 .preview-paper::after {
-  content: "Page " attr(data-page) " / " attr(data-total);
+  counter-increment: page;
+  content: 'Page ' counter(page) ' of ' attr(data-total);
   position: absolute;
   bottom: 10mm;
   right: 10mm;
@@ -51,10 +89,11 @@ a {
   color: #333;
   font-size: 20px;
   margin: 24px 0 16px;
-  border-bottom: 2px solid #3358ff;
+  border-bottom: 2px solid var(--accent-color);
   padding-bottom: 8px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  font-family: var(--font-heading);
 }
 
 .preview-paper h4 {
@@ -62,21 +101,13 @@ a {
   font-size: 16px;
   margin: 16px 0 8px;
   font-weight: 600;
+  font-family: var(--font-heading);
 }
 
 /* Additional page styling */
-.preview-paper:not(:first-child) {
-  margin-top: -20px; /* Overlap to show connection between pages */
-}
+/* Gap on container handles spacing between pages */
 
-.preview-paper:not(:last-child)::after {
-  content: "Page " attr(data-page) " / " attr(data-total);
-  position: absolute;
-  bottom: 10mm;
-  right: 10mm;
-  font-size: 10px;
-  color: #666;
-}
+
 
 /* Print */
 @media print {
@@ -94,24 +125,46 @@ a {
     display: none !important; 
   }
   
-  .layout { 
+  .layout {
     display: block !important;
     height: auto !important;
   }
-  
-  .preview { 
+
+  .preview-container {
+    overflow: visible !important;
+    height: auto !important;
+    display: block !important;
+    gap: 0 !important;
+  }
+
+  .preview {
     padding: 0 !important;
     height: auto !important;
     background: none !important;
   }
-  
-  .preview-paper { 
+
+  .preview-paper {
     width: 210mm !important;
     height: 297mm !important;
-    padding: 25mm !important;
+    padding: 25mm 25mm 35mm !important;
     margin: 0 !important;
     box-shadow: none !important;
     border-radius: 0 !important;
     position: relative !important;
+    page-break-after: always !important;
+    break-after: page !important;
+  }
+
+  .preview-paper:last-child {
+    page-break-after: avoid !important;
+    break-after: avoid !important;
+  }
+
+  .preview-paper::after {
+    content: none !important;
+  }
+
+  .preview-measure {
+    display: none !important;
   }
 }

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,2 +1,109 @@
+/* Sidebar layout styling */
+.sidebar {
+  position: relative;
+  background: var(--surface-color);
+  color: var(--text-color);
+  border-right: 1px solid var(--border-color);
+  transition: all 0.3s ease;
+  height: 100vh;
+  width: 100%;
+  flex-shrink: 0;
+  box-shadow: var(--subtle-shadow);
+}
+
+.sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.form-scroll {
+  overflow-x: hidden;
+  overflow-y: auto;
+  flex: 1;
+  padding: 24px 52px 80px 20px;
+  margin: 0 auto;
+}
+
+.sidebar > * {
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.layout.closed .sidebar {
+  width: 32px;
+  overflow: visible;
+}
+
+.layout.closed .form-scroll,
+.layout.closed .topbar {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.layout.closed .sidebar > *:not(.collapse) {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.collapse {
+  position: absolute;
+  top: 12px;
+  right: -32px;
+  width: 40px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--surface-color);
+  color: var(--muted-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid var(--border-color);
+}
+
+.collapse:hover {
+  background: var(--surface-color);
+  color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+  transform: none;
+}
+
+.collapse svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.25;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+}
+
+.layout.closed .collapse {
+  transform: rotate(180deg);
+  right: -36px;
+  background: var(--surface-color);
+}
+
+.collapse:hover svg {
+  opacity: 0.8;
+}
+
+.collapse:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.collapse::before {
+  content: '';
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 8px;
+  height: 24px;
+  background: linear-gradient(to right, transparent, var(--base-color));
+  pointer-events: none;
+}
 
 


### PR DESCRIPTION
## Summary
- introduce light and dark theme tokens with CSS variables and focus-ring updates
- add top-bar theme toggle that persists user preference
- wire app theme state to respect system settings and update document theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_689cbf2ec2a48332a76a9db3b0b59bbf