### PR TITLE
feat: add theme toggle and accessible AI slider

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -315,6 +315,7 @@ button:hover {
   border-color: var(--accent-color);
   padding: 8px 20px;
   font-weight: 600;
+  color: #fff;
   box-shadow: var(--subtle-shadow);
 }
 
@@ -324,14 +325,44 @@ button:hover {
   box-shadow: var(--elevated-shadow);
 }
 
+/* ghost button with subtle background so it stands out on the top bar */
 .btn.ghost {
-  background: var(--surface-color);
-  border-color: var(--border-color);
+  background: var(--surface);
+  border-color: var(--line);
+  color: var(--text-color);
+}
+.btn.ghost:hover {
+  background: var(--surface-2);
+}
+
+/* icon-only buttons */
+.btn.icon {
+  padding: 8px;
+  width: 36px;
+  height: 36px;
+  justify-content: center;
+}
+
+/* outline style for secondary actions */
+.btn.secondary {
+  background: transparent;
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
+.btn.secondary:hover {
+  background: var(--brand-tint);
+  box-shadow: var(--subtle-shadow);
 }
 
 .btn.ghost.active {
   border-color: var(--accent-color);
   color: var(--accent-color);
+}
+
+/* spacing for buttons inside cards */
+.card > .btn {
+  margin-top: 20px;
 }
 
 .card {
@@ -397,13 +428,14 @@ button:hover {
 
 .card h4 {
   font-size: 15px;
-  color: #e5edff;
+  color: var(--muted-text);
   margin: 16px 0 12px;
   font-weight: 500;
   opacity: 0.9;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 8px;
   position: relative;
 }
 
@@ -804,34 +836,4 @@ textarea {
   .preview-paper::before {
     display: none !important;
   }
-}
-
-.card h4{
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;   /* was space-between */
-  gap: 8px;                      /* space between text and X */
-}
-
-/* make sure nothing pushes it away */
-.card h4 .delete-btn{
-  margin-left: 0;                /* no auto margin pushing to the right */
-}
-
-.btn{
-  padding: 8px 12px;
-  margin-top: 20px;
-  border: none;
-  border-radius: 8px;
-  background: var(--accent-color);
-  color: #fff;
-  font-size: 14px;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-.btn:hover{
-  background: var(--accent-color-hover);
-  transform: scale(1.02);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,8 +17,10 @@ import ResumeImprover from './components/ResumeImprover';
 
 // Hooks
 import { useResumeData } from './hooks/useResumeData';
+import { useTheme } from './hooks/useTheme';
 
 function App() {
+  const { theme, toggleTheme } = useTheme();
   const {
     data,
     setData,
@@ -43,15 +45,18 @@ function App() {
   });
 
   return (
-    <SidebarLayout
-      topbar={
-        <TopBar
-          onPrint={handlePrint}
-          onReset={handleReset}
-          onDefault={handleDefault}
-        />
-      }
-      sidebar={
+    <div className={`app theme-${theme}`}>
+      <SidebarLayout
+        topbar={
+          <TopBar
+            onPrint={handlePrint}
+            onReset={handleReset}
+            onDefault={handleDefault}
+            onToggleTheme={toggleTheme}
+            theme={theme}
+          />
+        }
+        sidebar={
         <>
           <div className="grid grid-2">
             <label>
@@ -157,7 +162,7 @@ function App() {
               Include GPA
             </label>
             <EducationForm data={data} setData={setData} removeEducation={removeEducation} />
-            <button type="button" className="btn" onClick={addEducation}>
+            <button type="button" className="btn primary" onClick={addEducation}>
               Add Education
             </button>
           </CollapsibleCard>
@@ -168,21 +173,21 @@ function App() {
               setData={setData}
               removeExperience={removeExperience}
             />
-            <button type="button" className="btn" onClick={addExperience}>
+            <button type="button" className="btn primary" onClick={addExperience}>
               Add Experience
             </button>
           </CollapsibleCard>
 
           <CollapsibleCard title="Skills">
             <SkillForm data={data} setData={setData} removeSkill={removeSkill} />
-            <button type="button" className="btn" onClick={addSkill}>
+            <button type="button" className="btn primary" onClick={addSkill}>
               Add Skill
             </button>
           </CollapsibleCard>
 
           <CollapsibleCard title="Projects">
             <ProjectForm data={data} setData={setData} removeProject={removeProject} />
-            <button type="button" className="btn" onClick={addProject}>
+            <button type="button" className="btn primary" onClick={addProject}>
               Add Project
             </button>
           </CollapsibleCard>
@@ -192,6 +197,7 @@ function App() {
       }
       preview={<ResumePreview ref={printRef} data={data} />}
     />
+    </div>
   );
 }
 

--- a/src/components/AiSuggestions.jsx
+++ b/src/components/AiSuggestions.jsx
@@ -7,37 +7,12 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
   const [suggestions, setSuggestions] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [sectionErrors, setSectionErrors] = useState({
-    summary: null,
-    experiences: null,
-    projects: null,
-    skills: null,
-  });
+  const [progressStatus, setProgressStatus] = useState(null);
+  const [resultBanner, setResultBanner] = useState(null);
+  const [debugLogs, setDebugLogs] = useState([]);
+  const [showDebug, setShowDebug] = useState(false);
   const abortControllerRef = useRef(null);
 
-  const extractProjects = (data) => {
-    if (!data?.projects?.project?.length) return '';
-    let content = 'PROJECTS:\n';
-    data.projects.project.forEach((proj, i) => {
-      content += `${i + 1}. [projId=${proj.id}] ${proj.projname}\n`;
-      (proj.description || []).forEach(
-        (d) => d?.trim() && (content += `   • ${d}\n`)
-      );
-    });
-    return content.trim();
-  };
-
-  const extractExperiences = (data) => {
-    if (!data?.experiences?.jobs?.length) return '';
-    let content = 'EXPERIENCE:\n';
-    data.experiences.jobs.forEach((job, i) => {
-      content += `${i + 1}. [jobId=${job.id}] ${job.title} at ${job.company}\n`;
-      (job.description || []).forEach(
-        (d) => d?.trim() && (content += `   • ${d}\n`)
-      );
-    });
-    return content.trim();
-  };
 
   const extractSkillsSummary = (data) => {
     let content = '';
@@ -56,7 +31,6 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
   const sanitizeBullet = (str) =>
     (str || '')
       .replace(/[\n\r]+/g, ' ')
-      .replace(/["\\]/g, '')
       .replace(/\s+/g, ' ')
       .trim();
 
@@ -177,23 +151,12 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
     }
   };
 
-  const fetchWithRetry = async (fn, retries = 1) => {
-    let lastErr;
-    for (let i = 0; i <= retries; i++) {
-      try {
-        return await fn();
-      } catch (e) {
-        lastErr = e;
-      }
-    }
-    throw lastErr;
-  };
-
   async function generateImprovedContent() {
     setIsLoading(true);
     setSuggestions(null);
     setError(null);
-    setSectionErrors({ summary: null, experiences: null, projects: null, skills: null });
+    setResultBanner(null);
+    setProgressStatus(null);
 
     abortControllerRef.current = new AbortController();
 
@@ -202,82 +165,281 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
       dangerouslyAllowBrowser: true,
     });
 
-    const combined = {
-      summary: [],
-      projects: [],
-      experiences: [],
-      skills: { add: [], replace: [] },
-    };
-    const errors = {};
-
-    const skillsContent = extractSkillsSummary(resumeData);
-    const expContent = extractExperiences(resumeData);
-    const projContent = extractProjects(resumeData);
-
     const controller = abortControllerRef.current;
 
-    const request = async (systemPrompt, userPrompt) => {
-      const res = await groq.chat.completions.create(
-        {
-          model: 'llama-3.3-70b-versatile',
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt },
-          ],
-          temperature: 0.1,
-          top_p: 1,
-          max_tokens: 800,
-          stream: false,
-          response_format: { type: 'json_object' },
-        },
-        { signal: controller.signal }
-      );
-      return res?.choices?.[0]?.message?.content ?? '';
+    const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
+
+    const logRequest = (log) => {
+      setDebugLogs((prev) => [...prev.slice(-2), log]);
     };
 
-    const handleSection = async (section, content) => {
-      if (!content) return;
-      const prompts = {
-        skills: `You are an expert resume assistant. Return ONLY JSON: {"summary":[{"old":"","improved":"","action":"replace"|"add"}],"skills":{"add":[""],"replace":[{"old":"","improved":""}]}}`,
-        experiences: `You are an expert resume assistant. Return ONLY JSON: {"experiences":[{"id":"","title":"","items":[{"old":"","improved":"","action":"replace"|"add"}]}]}`,
-        projects: `You are an expert resume assistant. Return ONLY JSON: {"projects":[{"id":"","title":"","items":[{"old":"","improved":"","action":"replace"|"add"}]}]}`,
-      };
-      const system = prompts[section];
-      const user = `Analyze the following content and provide suggestions.\n\n${content}`.trim();
-      let text;
+    const callGroq = async ({ mode, section, entityId, system, user }) => {
+      const requestId = crypto.randomUUID();
+      const timestamp = new Date().toISOString();
+      const inputChars = user.length;
+      const inputTokens = Math.ceil((system.length + user.length) / 4);
       try {
-        text = await fetchWithRetry(() => request(system, user));
+        const res = await groq.chat.completions.create(
+          {
+            model: 'llama-3.3-70b-versatile',
+            messages: [
+              { role: 'system', content: system },
+              { role: 'user', content: user },
+            ],
+            temperature: 0.2,
+            top_p: 1,
+            max_tokens: 800,
+            stream: false,
+            response_format: { type: 'json_object' },
+          },
+          { signal: controller.signal }
+        );
+        const raw = res?.choices?.[0]?.message?.content ?? '';
+        try {
+          const parsed = JSON.parse(raw);
+          logRequest({
+            requestId,
+            timestamp,
+            mode,
+            section,
+            entityId,
+            inputChars,
+            inputTokens,
+            outputChars: raw.length,
+            snippet: raw.slice(0, 300),
+            outcome: 'parsed',
+            raw,
+          });
+          return parsed;
+        } catch (e) {
+          const repaired = safeParseJson(raw);
+          if (repaired) {
+            logRequest({
+              requestId,
+              timestamp,
+              mode,
+              section,
+              entityId,
+              inputChars,
+              inputTokens,
+              outputChars: raw.length,
+              snippet: raw.slice(0, 300),
+              outcome: 'repaired',
+              raw,
+            });
+            return repaired;
+          }
+          logRequest({
+            requestId,
+            timestamp,
+            mode,
+            section,
+            entityId,
+            inputChars,
+            inputTokens,
+            outputChars: raw.length,
+            snippet: raw.slice(0, 300),
+            error: e.message,
+            outcome: 'failed',
+            raw,
+          });
+          throw new Error('json_parse_failed');
+        }
+      } catch (err) {
+        const code = err?.response?.error?.code;
+        logRequest({
+          requestId,
+          timestamp,
+          mode,
+          section,
+          entityId,
+          inputChars,
+          inputTokens,
+          error: code ? `${code}: ${err.message}` : err.message,
+          outcome: 'failed',
+          raw: '',
+        });
+        throw err;
+      }
+    };
+
+      const retryEntity = async (fn) => {
+        for (let i = 0; i < 3; i++) {
+          try {
+            return await fn();
+          } catch (e) {
+            if (i < 2) await sleep([250, 750][i]);
+          }
+        }
+        return null;
+      };
+      const combined = {
+        summary: [],
+        projects: [],
+        experiences: [],
+        skills: { add: [], replace: [] },
+      };
+
+      const skillsContent = extractSkillsSummary(resumeData);
+      const jobs = resumeData?.experiences?.jobs || [];
+      const projects = resumeData?.projects?.project || [];
+      const total = jobs.length + projects.length + (skillsContent ? 1 : 0);
+      let success = 0;
+
+      const BASE_SYSTEM = 'Return ONLY a valid JSON object, no prose, no markdown, no code fences.';
+
+      const failed = {
+        experiences: jobs.length > 0,
+        projects: projects.length > 0,
+        skills: !!skillsContent,
+      };
+
+      try {
+        const system = `${BASE_SYSTEM} {"summary":[{"old":"","improved":"","action":"replace"|"add"}],"experiences":[{"id":"","title":"","items":[{"old":"","improved":"","action":"replace"|"add"}]}],"projects":[{"id":"","title":"","items":[{"old":"","improved":"","action":"replace"|"add"}]}],"skills":{"add":[""],"replace":[{"old":"","improved":""}]}}`;
+
+        const userParts = [];
+        jobs.forEach((job) => {
+          userParts.push(`JOB: ${job.title} at ${job.company}`);
+          (job.description || [])
+            .filter((d) => d?.trim())
+            .forEach((d) => userParts.push(`• ${d}`));
+        });
+        projects.forEach((proj) => {
+          userParts.push(`PROJECT: ${proj.projname}`);
+          (proj.description || [])
+            .filter((d) => d?.trim())
+            .forEach((d) => userParts.push(`• ${d}`));
+        });
+        if (skillsContent) userParts.push(skillsContent);
+
+        const parsed = await callGroq({
+          mode: 'all-in-one',
+          section: 'all',
+          entityId: 'all',
+          system,
+          user: userParts.join('\n'),
+        });
+        const cleaned = cleanParsed(parsed);
+        combined.summary.push(...cleaned.summary);
+        combined.skills.add.push(...cleaned.skills.add);
+        combined.skills.replace.push(...cleaned.skills.replace);
+        if (cleaned.experiences.length) {
+          combined.experiences.push(...cleaned.experiences);
+          failed.experiences = false;
+          success += jobs.length;
+        }
+        if (cleaned.projects.length) {
+          combined.projects.push(...cleaned.projects);
+          failed.projects = false;
+          success += projects.length;
+        }
+        if (
+          skillsContent &&
+          (cleaned.summary.length ||
+            cleaned.skills.add.length ||
+            cleaned.skills.replace.length)
+        ) {
+          failed.skills = false;
+          success += 1;
+        }
       } catch (e) {
-        errors[section] = e.message || 'Request failed.';
+        // combined call failed; fall back to per-entity
+      }
+
+      let processed = success;
+
+      if (failed.experiences) {
+        for (let j = 0; j < jobs.length; j++) {
+          const job = jobs[j];
+          setProgressStatus({ section: 'job', current: processed + 1, total });
+          const system = `${BASE_SYSTEM} {"experiences":[{"id":"${job.id}","title":"${job.title} at ${job.company}","items":[{"old":"","improved":"","action":"replace"|"add"}]}],"projects":[],"skills":{"add":[],"replace":[]}}`;
+          const user = (job.description || [])
+            .filter((d) => d?.trim())
+            .map((d) => `• ${d}`)
+            .join('\n');
+          const parsed = await retryEntity(() =>
+            callGroq({
+              mode: 'per-job',
+              section: 'experiences',
+              entityId: job.id,
+              system,
+              user,
+            })
+          );
+          if (parsed) {
+            const cleaned = cleanParsed(parsed);
+            combined.experiences.push(...cleaned.experiences);
+            combined.skills.add.push(...cleaned.skills.add);
+            combined.skills.replace.push(...cleaned.skills.replace);
+            success++;
+          }
+          processed++;
+          await sleep(120);
+        }
+      }
+
+      if (failed.projects) {
+        for (let p = 0; p < projects.length; p++) {
+          const proj = projects[p];
+          setProgressStatus({ section: 'project', current: processed + 1, total });
+          const system = `${BASE_SYSTEM} {"projects":[{"id":"${proj.id}","title":"${proj.projname}","items":[{"old":"","improved":"","action":"replace"|"add"}]}],"experiences":[],"skills":{"add":[],"replace":[]}}`;
+          const user = (proj.description || [])
+            .filter((d) => d?.trim())
+            .map((d) => `• ${d}`)
+            .join('\n');
+          const parsed = await retryEntity(() =>
+            callGroq({
+              mode: 'per-project',
+              section: 'projects',
+              entityId: proj.id,
+              system,
+              user,
+            })
+          );
+          if (parsed) {
+            const cleaned = cleanParsed(parsed);
+            combined.projects.push(...cleaned.projects);
+            combined.skills.add.push(...cleaned.skills.add);
+            combined.skills.replace.push(...cleaned.skills.replace);
+            success++;
+          }
+          processed++;
+          await sleep(120);
+        }
+      }
+
+      if (failed.skills && skillsContent) {
+        setProgressStatus({ section: 'skills', current: processed + 1, total });
+        const system = `${BASE_SYSTEM} {"summary":[{"old":"","improved":"","action":"replace"|"add"}],"skills":{"add":[""],"replace":[{"old":"","improved":""}]},"experiences":[],"projects":[]}`;
+        const parsed = await retryEntity(() =>
+          callGroq({
+            mode: 'skills-only',
+            section: 'skills',
+            entityId: 'skills',
+            system,
+            user: skillsContent,
+          })
+        );
+        if (parsed) {
+          const cleaned = cleanParsed(parsed);
+          combined.summary.push(...cleaned.summary);
+          combined.skills.add.push(...cleaned.skills.add);
+          combined.skills.replace.push(...cleaned.skills.replace);
+          success++;
+        }
+        processed++;
+      }
+
+      setProgressStatus(null);
+      if (failed.experiences || failed.projects || failed.skills)
+        setResultBanner({ success, total });
+      if (success === 0) {
+        setIsLoading(false);
+        setError("AI couldn't format suggestions this time. Try again.");
         return;
       }
-      const parsed = safeParseJson(text);
-      if (!parsed) return;
-      const cleaned = cleanParsed(parsed);
-      combined.summary.push(...cleaned.summary);
-      combined.projects.push(...cleaned.projects);
-      combined.experiences.push(...cleaned.experiences);
-      combined.skills.add.push(...cleaned.skills.add);
-      combined.skills.replace.push(...cleaned.skills.replace);
-    };
 
-    try {
-      await Promise.all([
-        handleSection('skills', skillsContent),
-        handleSection('experiences', expContent),
-        handleSection('projects', projContent),
-      ]);
-    } catch (err) {
-      if (err.name !== 'AbortError') {
-        setError(err.message || 'Failed to generate improvements.');
-      }
-      setIsLoading(false);
-      return;
-    }
-
-    setSectionErrors(errors);
-
-    const seenExp = new Set();
+      const seenExp = new Set();
     const expItems = [];
     combined.experiences.forEach((exp) => {
       exp.items.forEach((item, idx) => {
@@ -446,13 +608,27 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
           </div>
         )}
 
+        {progressStatus && (
+          <div className="loading">
+            <div className="spinner"></div>
+            <span>
+              Processing {progressStatus.section} ({progressStatus.current}/
+              {progressStatus.total})...
+            </span>
+          </div>
+        )}
+
         {error && <div className="error">{error}</div>}
+
+        {resultBanner && !error && (
+          <div className="retry-banner">
+            Generated suggestions for {resultBanner.success} of{' '}
+            {resultBanner.total} items.
+          </div>
+        )}
 
         {suggestions && !isLoading && (
           <div className="suggestion-content">
-            {sectionErrors.summary && (
-              <div className="error">Summary: {sectionErrors.summary}</div>
-            )}
             {suggestions.summary.map((item) => (
               <div
                 key={item.key}
@@ -464,22 +640,19 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
                 >
                   ×
                 </button>
-                {item.context && <h5>{item.context}</h5>}
+                {item.context && <h5 className="card-title">{item.context}</h5>}
                 <BeforeAfterSlider before={item.old} after={item.improved} />
-                <div className="row gap-s">
-                  <button className="btn" onClick={() => handleAction('replace', item)}>
+                <div className="actions">
+                  <button className="btn primary" onClick={() => handleAction('replace', item)}>
                     Replace
                   </button>
-                  <button className="btn" onClick={() => handleAction('add', item)}>
+                  <button className="btn secondary" onClick={() => handleAction('add', item)}>
                     Add
                   </button>
                 </div>
               </div>
             ))}
 
-            {sectionErrors.experiences && (
-              <div className="error">Experiences: {sectionErrors.experiences}</div>
-            )}
             {suggestions.experiences.map((item) => (
               <div
                 key={item.key}
@@ -491,22 +664,19 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
                 >
                   ×
                 </button>
-                {item.context && <h5>{item.context}</h5>}
+                {item.context && <h5 className="card-title">{item.context}</h5>}
                 <BeforeAfterSlider before={item.old} after={item.improved} />
-                <div className="row gap-s">
-                  <button className="btn" onClick={() => handleAction('replace', item)}>
+                <div className="actions">
+                  <button className="btn primary" onClick={() => handleAction('replace', item)}>
                     Replace
                   </button>
-                  <button className="btn" onClick={() => handleAction('add', item)}>
+                  <button className="btn secondary" onClick={() => handleAction('add', item)}>
                     Add
                   </button>
                 </div>
               </div>
             ))}
 
-            {sectionErrors.projects && (
-              <div className="error">Projects: {sectionErrors.projects}</div>
-            )}
             {suggestions.projects.map((item) => (
               <div
                 key={item.key}
@@ -518,22 +688,19 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
                 >
                   ×
                 </button>
-                {item.context && <h5>{item.context}</h5>}
+                {item.context && <h5 className="card-title">{item.context}</h5>}
                 <BeforeAfterSlider before={item.old} after={item.improved} />
-                <div className="row gap-s">
-                  <button className="btn" onClick={() => handleAction('replace', item)}>
+                <div className="actions">
+                  <button className="btn primary" onClick={() => handleAction('replace', item)}>
                     Replace
                   </button>
-                  <button className="btn" onClick={() => handleAction('add', item)}>
+                  <button className="btn secondary" onClick={() => handleAction('add', item)}>
                     Add
                   </button>
                 </div>
               </div>
             ))}
 
-            {sectionErrors.skills && (
-              <div className="error">Skills: {sectionErrors.skills}</div>
-            )}
             {suggestions.skills.length > 0 && (
               <div className="skill-suggestions">
                 {suggestions.skills.map((item) => (
@@ -584,6 +751,37 @@ function AiSuggestions({ resumeData, onSuggestionReceived }) {
           </p>
         )}
       </div>
+
+      {import.meta.env.DEV && debugLogs.length > 0 && (
+        <div className="ai-debug">
+          <button
+            className="btn debug-toggle"
+            onClick={() => setShowDebug((s) => !s)}
+          >
+            AI Debug
+          </button>
+          {showDebug && (
+            <ul>
+              {debugLogs.map((log) => (
+                <li key={log.requestId}>
+                  <span>
+                    {log.section}
+                    {log.entityId ? ` (${log.entityId})` : ''}: {log.outcome}
+                  </span>
+                  {log.raw && (
+                    <button
+                      className="btn"
+                      onClick={() => navigator.clipboard.writeText(log.raw)}
+                    >
+                      copy raw
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/BeforeAfterSlider.jsx
+++ b/src/components/BeforeAfterSlider.jsx
@@ -1,24 +1,127 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import '../styles/ai-suggestions.css';
 
 export default function BeforeAfterSlider({ before = '', after = '' }) {
-  const [pos, setPos] = useState(50);
+  const containerRef = useRef(null);
+  const handleRef = useRef(null);
+  const prevRef = useRef(50);
+  const [pos, setPos] = useState(50); // percentage of before reveal
+  const [dragging, setDragging] = useState(false);
+
+  const clamp = (p, rect) => {
+    let v = Math.min(Math.max(p, 0), 100);
+    // snap points
+    const px = (v / 100) * rect.width;
+    const snaps = [25, 50, 75];
+    for (const s of snaps) {
+      const spx = (s / 100) * rect.width;
+      if (Math.abs(px - spx) <= 8) {
+        v = s;
+        break;
+      }
+    }
+    return v;
+  };
+
+  const updatePos = (clientX) => {
+    const rect = containerRef.current.getBoundingClientRect();
+    const pct = ((clientX - rect.left) / rect.width) * 100;
+    setPos(clamp(pct, rect));
+  };
+
+  const startDrag = (e) => {
+    e.preventDefault();
+    const clientX = e.clientX ?? e.touches?.[0]?.clientX;
+    if (clientX != null) updatePos(clientX);
+    setDragging(true);
+    handleRef.current.focus();
+  };
+
+  useEffect(() => {
+    if (!dragging) return;
+    const move = (e) => {
+      const clientX = e.clientX ?? e.touches?.[0]?.clientX;
+      if (clientX != null) updatePos(clientX);
+    };
+    const up = () => setDragging(false);
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up, { once: true });
+    return () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+  }, [dragging]);
+
+  const handleKey = (e) => {
+    const rect = containerRef.current.getBoundingClientRect();
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      const step = e.shiftKey ? 10 : 5;
+      const delta = e.key === 'ArrowLeft' ? -step : step;
+      setPos((p) => clamp(p + delta, rect));
+      e.preventDefault();
+    } else if (e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault();
+      prevRef.current = pos;
+      setPos(50);
+      const restore = () => {
+        setPos(prevRef.current);
+        window.removeEventListener('keyup', restore);
+      };
+      window.addEventListener('keyup', restore);
+    }
+  };
+
+  const handleDouble = () => {
+    setPos((p) => (p < 50 ? 65 : 35));
+  };
+
+  const handlePos = (() => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return pos;
+    const margin = (8 / rect.width) * 100;
+    return Math.min(Math.max(pos, margin), 100 - margin);
+  })();
+
   return (
-    <div className="ba-slider">
-      <div className="ba-before" style={{ width: before ? `${pos}%` : '0%' }}>
-        {before && <p>{before}</p>}
-      </div>
+    <div
+      className="ba-slider"
+      ref={containerRef}
+      onPointerDown={(e) => {
+        if (e.target === handleRef.current) return;
+        startDrag(e);
+      }}
+    >
       <div className="ba-after">
+        <span className="ba-label after">IMPROVED</span>
         <p>{after}</p>
       </div>
       {before && (
-        <input
-          type="range"
-          min="0"
-          max="100"
-          value={pos}
-          onChange={(e) => setPos(e.target.value)}
-        />
+        <div
+          className="ba-before"
+          style={{ clipPath: `inset(0 calc(100% - ${pos}%) 0 0)` }}
+        >
+          <span className="ba-label before">BEFORE</span>
+          <p>{before}</p>
+        </div>
+      )}
+          {before && (
+        <>
+          <div className="ba-track" style={{ left: `${pos}%` }} />
+          <button
+            ref={handleRef}
+            className="ba-handle"
+            style={{ left: `${handlePos}%` }}
+            onPointerDown={startDrag}
+            onKeyDown={handleKey}
+            onDoubleClick={handleDouble}
+            role="slider"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(pos)}
+            aria-label="Comparison slider"
+            aria-valuetext={`Showing ${Math.round(pos)}% original, ${100 - Math.round(pos)}% improved`}
+          />
+        </>
       )}
     </div>
   );

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,17 +1,26 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPrint, faRotateLeft, faStar } from '@fortawesome/free-solid-svg-icons';
+import { faPrint, faRotateLeft, faStar, faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
 
-export default function TopBar({ onPrint, onReset, onDefault }) {
+export default function TopBar({ onPrint, onReset, onDefault, onToggleTheme, theme }) {
   return (
     <div className="topbar">
       <div className="left">
         <h2>Resume Builder</h2>
       </div>
       <div className="right">
-        <button type="button" className="btn ghost" onClick={onDefault} title="Load sample data">
+        <button
+          type="button"
+          className="btn ghost icon"
+          onClick={onToggleTheme}
+          title="Toggle theme"
+          aria-label="Toggle theme"
+        >
+          <FontAwesomeIcon icon={theme === 'dark' ? faSun : faMoon} />
+        </button>
+        <button type="button" className="btn primary" onClick={onDefault} title="Load sample data">
           <FontAwesomeIcon icon={faStar} /> Sample
         </button>
-        <button type="button" className="btn ghost" onClick={onReset} title="Clear all fields">
+        <button type="button" className="btn primary" onClick={onReset} title="Clear all fields">
           <FontAwesomeIcon icon={faRotateLeft} /> Reset
         </button>
         <button type="button" className="btn primary" onClick={onPrint} title="Print / Save PDF">

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export function useTheme() {
+  const getInitial = () => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+    if (stored === 'light' || stored === 'dark') return stored;
+    if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  };
+
+  const [theme, setTheme] = useState(getInitial);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove('theme-light', 'theme-dark');
+    root.classList.add(`theme-${theme}`);
+    try {
+      localStorage.setItem('theme', theme);
+    } catch {
+      /* ignore */
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+
+  return { theme, setTheme, toggleTheme };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,34 +1,82 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Source+Sans+Pro:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&family=Source+Sans+Pro:wght@400;600&display=swap');
 
+/* Theme tokens */
 :root {
-  /* Color Palette */
-  --base-color: #0f172a; /* Deep Navy */
-  --surface-color: #1e293b; /* Card surface */
-  --accent-color: #0ea5e9; /* Teal accent */
-  --accent-color-hover: #38bdf8;
-  --text-color: #f1f5f9;
-  --muted-text: #94a3b8;
-  --card-bg: var(--surface-color);
-  --border-color: #334155;
-  --subtle-shadow: 0 4px 6px rgba(0,0,0,0.1);
-  --elevated-shadow: 0 8px 16px rgba(0,0,0,0.15);
+  /* semantic tokens - light theme defaults */
+  --surface: #f7f9fc;
+  --surface-2: #ffffff;
+  --line: #e5eaf2;
+  --text-primary: #1c1e21;
+  --text-secondary: #6b7280;
+  --brand: #3358ff;
+  --brand-tint: #dde5ff;
+  --success: #3bcf85;
+  --danger: #ff4d4f;
+  --focus-ring: #3358ff;
+  --shadow-elev-1: 0 1px 2px rgba(0,0,0,0.05), 0 1px 3px rgba(0,0,0,0.1);
+  --shadow-elev-2: 0 4px 6px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.06);
+
+  /* legacy variable mapping */
+  --base-color: var(--surface);
+  --surface-color: var(--surface-2);
+  --accent-color: var(--brand);
+  --accent-color-hover: var(--brand-tint);
+  --text-color: var(--text-primary);
+  --muted-text: var(--text-secondary);
+  --card-bg: var(--surface-2);
+  --border-color: var(--line);
+  --subtle-shadow: var(--shadow-elev-1);
+  --elevated-shadow: var(--shadow-elev-2);
 
   /* Typography */
-  --font-heading: 'Montserrat', sans-serif;
+  --font-heading: 'Poppins', sans-serif;
   --font-body: 'Source Sans Pro', sans-serif;
 
   font-family: var(--font-body);
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
   color: var(--text-color);
   background-color: var(--base-color);
+  color-scheme: light;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.theme-dark {
+  --surface: #0f131a;
+  --surface-2: #0b1017;
+  --line: #1c2330;
+  --text-primary: #e9f0ff;
+  --text-secondary: #9fb3d9;
+  --brand: #3358ff;
+  --brand-tint: #223a9f;
+  --success: #37b879;
+  --danger: #ff595a;
+  --focus-ring: #6c8cff;
+  --shadow-elev-1: 0 1px 2px rgba(0,0,0,0.4);
+  --shadow-elev-2: 0 4px 8px rgba(0,0,0,0.6);
+
+  --base-color: var(--surface);
+  --surface-color: var(--surface-2);
+  --accent-color: var(--brand);
+  --accent-color-hover: var(--brand-tint);
+  --text-color: var(--text-primary);
+  --muted-text: var(--text-secondary);
+  --card-bg: var(--surface-2);
+  --border-color: var(--line);
+  --subtle-shadow: var(--shadow-elev-1);
+  --elevated-shadow: var(--shadow-elev-2);
+
+  color-scheme: dark;
+}
+
+/* explicit light class for completeness */
+.theme-light {
+  color-scheme: light;
 }
 
 a {

--- a/src/styles/ai-suggestions.css
+++ b/src/styles/ai-suggestions.css
@@ -115,50 +115,123 @@
 
 .suggestion-card {
   position: relative;
-  background: var(--surface-color);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-bottom: 12px;
-  transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.06);
+  transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.suggestion-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-elev-2);
+  border-color: var(--accent-color);
 }
 
 .ba-slider {
   position: relative;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--line);
   border-radius: 6px;
   overflow: hidden;
   margin: 8px 0;
+  background: var(--surface-2);
 }
 
-.ba-slider p {
-  margin: 0;
-  padding: 8px 12px;
-  line-height: 1.4;
+.ba-after,
+.ba-before {
+  position: relative;
+  min-height: 100%;
 }
 
 .ba-after {
-  background: var(--surface-color);
+  padding: 0 16px;
+  background: color-mix(in srgb, var(--brand) 10%, transparent);
+  color: var(--text-primary);
 }
 
 .ba-before {
   position: absolute;
   top: 0;
   left: 0;
-  height: 100%;
-  background: var(--accent-color);
-  color: #000;
+  bottom: 0;
+  padding: 0 16px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  will-change: clip-path;
 }
 
-.ba-slider input[type='range'] {
+.ba-slider p {
+  margin: 0;
+  line-height: 1.4;
+  padding: 12px 0;
+}
+
+
+.ba-track {
   position: absolute;
-  bottom: -12px;
-  left: 0;
-  width: 100%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--brand);
+  transform: translateX(-50%);
+  pointer-events: none;
+  will-change: left;
 }
 
-.suggestion-card:hover {
-  border-color: var(--accent-color);
+.theme-dark .ba-track {
+  background: var(--brand-tint);
+}
+
+.ba-handle {
+  position: absolute;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--surface-2);
+  border: 1px solid var(--brand);
+  box-shadow: var(--shadow-elev-1);
+  transform: translate(-50%, -50%);
+  cursor: ew-resize;
+  touch-action: none;
+  will-change: left, transform;
+  transition: transform 0.1s ease;
+}
+
+.ba-handle:hover {
+  transform: translate(-50%, -50%) scale(1.15);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand) 25%, transparent);
+}
+
+.ba-handle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.theme-dark .ba-handle {
+  border-color: var(--brand-tint);
+}
+
+.ba-label {
+  position: absolute;
+  top: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  user-select: none;
+  pointer-events: none;
+}
+
+.ba-label.before {
+  left: 8px;
+}
+
+.ba-label.after {
+  right: 8px;
 }
 
 .skill-suggestions {
@@ -190,14 +263,14 @@
   right: 6px;
   background: transparent;
   border: none;
-  color: var(--muted-text);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
   line-height: 1;
 }
 
 .remove-btn:hover {
-  color: var(--text-color);
+  color: var(--accent-color);
 }
 
 .skill-chip .remove-btn {
@@ -215,5 +288,48 @@
 
 .fade-out {
   opacity: 0;
-  transform: scale(0.95);
+  transform: translateY(-8px);
+}
+
+.card-title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.retry-banner {
+  margin: 8px 0;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--brand) 10%, transparent);
+  border: 1px solid var(--brand);
+  border-radius: 6px;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.ai-debug {
+  margin-top: 12px;
+  font-size: 12px;
+}
+
+.ai-debug ul {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+
+.ai-debug li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
 }


### PR DESCRIPTION
## Summary
- refine theme toggle to icon-only with backgrounded ghost button
- restyle AI suggestion cards with rounded shadowed layout and right-aligned actions
- polish comparison slider with brand-tinted panels and accessible handle
- split AI suggestion requests per job/project with progress banner and results summary
- ensure light theme buttons and subheaders use accent colors for visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689dc73119e083328a930f5aade008e3